### PR TITLE
DIGISOS-1319: Fiks tag+release på riktig branch med GitHub app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,31 @@ jobs:
             export GIT_COMMIT_DATE=$(git log -1 --pretty='%ad' --date=format:'%Y%m%d.%H%M')
             export VERSION=1.0_${GIT_COMMIT_DATE}_${GIT_COMMIT_HASH}
 
+            echo "export GIT_TAG=\"$VERSION\"" >> $BASH_ENV
             echo "export DOCKER_TAG=\"docker.pkg.github.com/navikt/$CIRCLE_PROJECT_REPONAME/$CIRCLE_PROJECT_REPONAME:$VERSION\"" >> $BASH_ENV
+      - run:
+          name: Create tag and release
+          command: |
+            export GIT_COMMIT_MESSAGE=$(git log --format=%B -n 1 | sed ':a;N;$!ba;s/\n/\\n/g')
+            echo $DIGISOS_KEY | tr '_' '\n' > digisos.key
+
+            set -eo pipefail
+            git clone https://github.com/navikt/github-apps-support.git
+            export PATH=`pwd`/github-apps-support/bin:$PATH
+            export GH_TOKEN=$(generate-installation-token.sh `generate-jwt.sh digisos.key $DIGISOS_APPID`)
+            rm digisos.key
+
+            curl -X POST "https://api.github.com/repos/navikt/$CIRCLE_PROJECT_REPONAME/git/tags" \
+                -H "Accept: application/vnd.github.v3.full+json" \
+                -H "Authorization: token $GH_TOKEN" \
+                -H "Content-Type: application/json" \
+                --data '{"tag": "'$GIT_TAG'", "message": "'$GIT_TAG'", "object": "'$CIRCLE_SHA1'", "type": "commit"}'
+
+            curl -X POST "https://api.github.com/repos/navikt/$CIRCLE_PROJECT_REPONAME/releases" \
+                -H "Accept: application/vnd.github.v3.full+json" \
+                -H "Authorization: token $GH_TOKEN" \
+                -H "Content-Type: application/json" \
+                --data '{"tag_name": "'$GIT_TAG'", "target_commitish": "'$CIRCLE_SHA1'", "name": "'$GIT_TAG'", "body": "'"$GIT_COMMIT_MESSAGE"'"}'
       - run:
           name: Build docker image
           command: docker build -t $DOCKER_TAG .


### PR DESCRIPTION
Bruker digisos-ci til å lage tag+release slik at releasen (Docker-image) blir knyttet til riktig branch+commit.