### PR TITLE
Bruk index til å fjerne filer fra filvisning i stedet for filnavn

### DIFF
--- a/src/components/oppgaver/FilView.tsx
+++ b/src/components/oppgaver/FilView.tsx
@@ -10,7 +10,7 @@ import {FormattedMessage} from "react-intl";
 
 type ClickEvent = React.MouseEvent<HTMLAnchorElement, MouseEvent> | React.MouseEvent<HTMLButtonElement, MouseEvent>;
 
-const FilView: React.FC<{ fil: Fil, oppgaveElement?: OppgaveElement }> = ({fil, oppgaveElement}) => {
+const FilView: React.FC<{ index: number, fil: Fil, oppgaveElement?: OppgaveElement }> = ({index, fil, oppgaveElement}) => {
     const storrelse: string = formatBytes(fil.file ? fil.file.size : 0);
     const dispatch = useDispatch();
 
@@ -20,7 +20,8 @@ const FilView: React.FC<{ fil: Fil, oppgaveElement?: OppgaveElement }> = ({fil, 
                 ? InnsynsdataActionTypeKeys.FJERN_FIL_FOR_OPPLASTING
                 : InnsynsdataActionTypeKeys.FJERN_FIL_FOR_ETTERSENDELSE,
             oppgaveElement: oppgaveElement,
-            fil: fil
+            fil: fil,
+            index: index
         });
         event.preventDefault();
     };

--- a/src/components/oppgaver/OppgaveView.tsx
+++ b/src/components/oppgaver/OppgaveView.tsx
@@ -215,7 +215,7 @@ const OppgaveView: React.FC<Props> = ({oppgave, oppgaverErFraInnsyn, oppgaveInde
                 )}
 
                 {oppgaveElement.filer && oppgaveElement.filer.length > 0 && oppgaveElement.filer.map((fil: Fil, index: number) =>
-                    <FilView key={index} fil={fil} oppgaveElement={oppgaveElement}/>
+                    <FilView key={index} fil={fil} oppgaveElement={oppgaveElement} index={index}/>
                 )}
 
             </div>

--- a/src/components/vedlegg/EttersendelseView.tsx
+++ b/src/components/vedlegg/EttersendelseView.tsx
@@ -121,7 +121,7 @@ const EttersendelseView: React.FC = () => {
                     </Normaltekst>
 
                     {filer && filer.length > 0 && filer.map((fil: Fil, index: number) =>
-                        <FilView key={index} fil={fil}/>
+                        <FilView key={index} fil={fil} index={index}/>
                     )}
 
                     {kanLasteOppVedlegg && (

--- a/src/redux/innsynsdata/innsynsdataReducer.ts
+++ b/src/redux/innsynsdata/innsynsdataReducer.ts
@@ -260,7 +260,8 @@ const InnsynsdataReducer: Reducer<InnsynsdataType, InnsynsdataActionType & Vedle
                     return {
                         ...oppgave,
                         oppgaveElementer: oppgave.oppgaveElementer.map((oppgaveElement) => {
-                            if (oppgaveElement.dokumenttype === action.oppgaveElement.dokumenttype) {
+                            if (oppgaveElement.dokumenttype === action.oppgaveElement.dokumenttype &&
+                                oppgaveElement.tilleggsinformasjon === action.oppgaveElement.tilleggsinformasjon) {
                                 return {
                                     ...oppgaveElement,
                                     filer: (oppgaveElement.filer && oppgaveElement.filer.filter((fil: Fil, index: number) => {

--- a/src/redux/innsynsdata/innsynsdataReducer.ts
+++ b/src/redux/innsynsdata/innsynsdataReducer.ts
@@ -120,6 +120,7 @@ export interface InnsynsdataActionType {
 
 export interface VedleggActionType {
     type: InnsynsdataActionTypeKeys,
+    index: number,
     fil: Fil;
     oppgaveElement: OppgaveElement;
     status?: string;
@@ -263,10 +264,7 @@ const InnsynsdataReducer: Reducer<InnsynsdataType, InnsynsdataActionType & Vedle
                                 return {
                                     ...oppgaveElement,
                                     filer: (oppgaveElement.filer && oppgaveElement.filer.filter((fil: Fil, index: number) => {
-                                        if (action.fil && fil.filnavn === action.fil.filnavn) {
-                                            return false;
-                                        }
-                                        return true;
+                                        return index !== action.index;
                                     }))
                                 }
                             }
@@ -368,8 +366,8 @@ const InnsynsdataReducer: Reducer<InnsynsdataType, InnsynsdataActionType & Vedle
                 ...state,
                 ettersendelse: {
                     ...state.ettersendelse,
-                    filer: state.ettersendelse.filer.filter((fil: Fil) => {
-                        return !(action.fil && fil.filnavn === action.fil.filnavn);
+                    filer: state.ettersendelse.filer.filter((fil: Fil, index: number) => {
+                        return index !== action.index;
                     })
                 }
             };


### PR DESCRIPTION
Bruker index til å fjerne filer fra lista over filer som skal lastes opp i stedet for filnavn, slik at ikke trykk på fjern/søppelbøtte fører til at alle filer med samme navn fjernes.