### PR TITLE
ekstra sjekk i SakPanel om fiksDigisosId === null || undefined

### DIFF
--- a/src/saksoversikt/sakpanel/SakPanel.tsx
+++ b/src/saksoversikt/sakpanel/SakPanel.tsx
@@ -29,7 +29,7 @@ const SakPanel: React.FC<Props> = ({fiksDigisosId, tittel, status, oppdatert, ur
 
     let dispatchUrl = "/innsyn/" + fiksDigisosId + "/status";
     let hrefUrl = "/sosialhjelp" + dispatchUrl;
-    if(fiksDigisosId === null) {
+    if(fiksDigisosId === null || fiksDigisosId === undefined) {
         hrefUrl = url;
     }
 


### PR DESCRIPTION
nytt forsøk på å finne ut hvorfor frontend kaller backend med fiksDigisosId = undefined