### PR TITLE
Inkluderer charset=utf-8 når contentType er application/json

### DIFF
--- a/src/utils/restUtils.ts
+++ b/src/utils/restUtils.ts
@@ -89,7 +89,7 @@ export enum REST_STATUS {
 
 export const getHeaders = (contentType?: string) => {
     let headers = new Headers({
-        "Content-Type": (contentType ? contentType : "application/json"),
+        "Content-Type": (contentType ? contentType : "application/json; charset=utf-8"),
         "Accept": "application/json, text/plain, */*"
     });
     // Browser setter content type header automatisk til multipart/form-data: boundary xyz


### PR DESCRIPTION
Fordi backend sin json-parser mener at JSON alltid skal være UTF-8 og krever derfor dette.