### PR TITLE
Feature/feilmelding ved opplasting i flere oppgave element

### DIFF
--- a/src/components/oppgaver/FilView.tsx
+++ b/src/components/oppgaver/FilView.tsx
@@ -11,7 +11,7 @@ import {REST_STATUS} from "../../utils/restUtils";
 
 type ClickEvent = React.MouseEvent<HTMLAnchorElement, MouseEvent> | React.MouseEvent<HTMLButtonElement, MouseEvent>;
 
-const FilView: React.FC<{ index: number, fil: Fil, oppgaveElement?: OppgaveElement }> = ({index, fil, oppgaveElement}) => {
+const FilView: React.FC<{ vedleggIndex: number, fil: Fil, oppgaveElement?: OppgaveElement }> = ({vedleggIndex, fil, oppgaveElement}) => {
     const storrelse: string = formatBytes(fil.file ? fil.file.size : 0);
     const dispatch = useDispatch();
 
@@ -22,7 +22,7 @@ const FilView: React.FC<{ index: number, fil: Fil, oppgaveElement?: OppgaveEleme
                 : InnsynsdataActionTypeKeys.FJERN_FIL_FOR_ETTERSENDELSE,
             oppgaveElement: oppgaveElement,
             fil: fil,
-            index: index
+            vedleggIndex: vedleggIndex
         });
         event.preventDefault();
     };

--- a/src/components/oppgaver/OppgaveView.tsx
+++ b/src/components/oppgaver/OppgaveView.tsx
@@ -179,8 +179,8 @@ const OppgaveView: React.FC<Props> = ({oppgave, oppgaverErFraInnsyn, oppgaveInde
                     <VedleggActionsView vedlegg={vedlegg} key={index}/>
                 )}
 
-                {oppgaveElement.filer && oppgaveElement.filer.length > 0 && oppgaveElement.filer.map((fil: Fil, index: number) =>
-                    <FilView key={index} fil={fil} oppgaveElement={oppgaveElement} index={index}/>
+                {oppgaveElement.filer && oppgaveElement.filer.length > 0 && oppgaveElement.filer.map((fil: Fil, vedleggIndex: number) =>
+                    <FilView key={vedleggIndex} fil={fil} oppgaveElement={oppgaveElement} vedleggIndex={vedleggIndex}/>
                 )}
 
                 {(ulovligFiltypeOppgaveIndex === id) && (

--- a/src/components/oppgaver/Oppgaver.tsx
+++ b/src/components/oppgaver/Oppgaver.tsx
@@ -97,7 +97,7 @@ const Oppgaver: React.FC<Props> = ({oppgaver, leserData}) => {
         }
 
         let formData = opprettFormDataMedVedleggFraOppgaver(oppgaver);
-        const sti: InnsynsdataSti = InnsynsdataSti.SEND_VEDLEGG;
+        const sti: InnsynsdataSti = InnsynsdataSti.VEDLEGG;
         const path = innsynsdataUrl(fiksDigisosId, sti);
         dispatch(settRestStatus(InnsynsdataSti.OPPGAVER, REST_STATUS.PENDING));
 
@@ -106,17 +106,22 @@ const Oppgaver: React.FC<Props> = ({oppgaver, leserData}) => {
         fetchPost(path, formData, "multipart/form-data").then((filRespons: any) => {
             let harFeil: boolean = false;
             if (Array.isArray(filRespons)) {
-                for (var index = 0; index < filRespons.length; index++) {
-                    const fileItem = filRespons[index];
-                    if (fileItem.status !== "OK") {
-                        harFeil = true;
+                for (let oppgaveIndex = 0; oppgaveIndex < filRespons.length; oppgaveIndex++) {
+                    for (let vedleggIndex = 0; vedleggIndex < filRespons[oppgaveIndex].filer.length; vedleggIndex++) {
+                        const fileItem = filRespons[oppgaveIndex].filer[vedleggIndex];
+                        if (fileItem.status !== "OK") {
+                            harFeil = true;
+                        }
+                        dispatch({
+                            type: InnsynsdataActionTypeKeys.SETT_STATUS_FOR_FIL,
+                            fil: {filnavn: fileItem.filnavn} as Fil,
+                            status: fileItem.status,
+                            innsendelsesfrist: filRespons[oppgaveIndex].innsendelsesfrist,
+                            dokumenttype: filRespons[oppgaveIndex].type,
+                            tilleggsinfo: filRespons[oppgaveIndex].tilleggsinfo,
+                            vedleggIndex: vedleggIndex,
+                        });
                     }
-                    dispatch({
-                        type: InnsynsdataActionTypeKeys.SETT_STATUS_FOR_FIL,
-                        fil: {filnavn: fileItem.filnavn} as Fil,
-                        status: fileItem.status,
-                        index: index
-                    });
                 }
             }
             if (harFeil) {

--- a/src/components/vedlegg/EttersendelseView.tsx
+++ b/src/components/vedlegg/EttersendelseView.tsx
@@ -91,15 +91,16 @@ const EttersendelseView: React.FC = () => {
         }
 
         let formData = opprettFormDataMedVedleggFraFiler(filer);
-        const sti: InnsynsdataSti = InnsynsdataSti.SEND_VEDLEGG;
+        const sti: InnsynsdataSti = InnsynsdataSti.VEDLEGG;
         const path = innsynsdataUrl(fiksDigisosId, sti);
         dispatch(settRestStatus(InnsynsdataSti.VEDLEGG, REST_STATUS.PENDING));
 
         fetchPost(path, formData, "multipart/form-data").then((filRespons: any) => {
             let harFeil: boolean = false;
-            if (Array.isArray(filRespons)) {
-                for (let index = 0; index < filRespons.length; index++) {
-                    const fileItem = filRespons[index];
+            let vedlegg = filRespons[0].filer;
+            if (Array.isArray(vedlegg)) {
+                for (let vedleggIndex = 0; vedleggIndex < vedlegg.length; vedleggIndex++) {
+                    const fileItem = vedlegg[vedleggIndex];
                     if (fileItem.status !== "OK") {
                         harFeil = true;
                     }
@@ -107,7 +108,7 @@ const EttersendelseView: React.FC = () => {
                         type: InnsynsdataActionTypeKeys.SETT_STATUS_FOR_ETTERSENDELSESFIL,
                         fil: {filnavn: fileItem.filnavn} as Fil,
                         status: fileItem.status,
-                        index: index
+                        vedleggIndex: vedleggIndex
                     });
                 }
             }
@@ -140,8 +141,8 @@ const EttersendelseView: React.FC = () => {
                         <FormattedMessage id="andre_vedlegg.tilleggsinfo"/>
                     </Normaltekst>
 
-                    {filer && filer.length > 0 && filer.map((fil: Fil, index: number) =>
-                        <FilView key={index} fil={fil} index={index}/>
+                    {filer && filer.length > 0 && filer.map((fil: Fil, vedleggIndex: number) =>
+                        <FilView key={vedleggIndex} fil={fil} vedleggIndex={vedleggIndex}/>
                     )}
 
                     {kanLasteOppVedlegg && (

--- a/src/utils/vedleggUtils.test.ts
+++ b/src/utils/vedleggUtils.test.ts
@@ -38,6 +38,7 @@ const expectedOppgaverMetadata = JSON.stringify([
     {
         type: oppgave.oppgaveElementer[0].dokumenttype,
         tilleggsinfo: oppgave.oppgaveElementer[0].tilleggsinformasjon,
+        innsendelsesfrist: oppgave.innsendelsesfrist,
         filer: [
             {filnavn: pngFile.filnavn},
             {filnavn: jpgFile.filnavn}
@@ -46,6 +47,7 @@ const expectedOppgaverMetadata = JSON.stringify([
     {
         type: oppgave.oppgaveElementer[1].dokumenttype,
         tilleggsinfo: oppgave.oppgaveElementer[1].tilleggsinformasjon,
+        innsendelsesfrist: oppgave.innsendelsesfrist,
         filer: [
             {filnavn: pdfFile.filnavn}
         ]
@@ -53,6 +55,7 @@ const expectedOppgaverMetadata = JSON.stringify([
     {
         type: oppgave.oppgaveElementer[2].dokumenttype,
         tilleggsinfo: oppgave.oppgaveElementer[2].tilleggsinformasjon,
+        innsendelsesfrist: oppgave.innsendelsesfrist,
         filer: [
             {filnavn: jpgFile.filnavn},
             {filnavn: jpgFile.filnavn}

--- a/src/utils/vedleggUtils.ts
+++ b/src/utils/vedleggUtils.ts
@@ -5,6 +5,7 @@ interface Metadata {
     type: string,
     tilleggsinfo: string | undefined
     filer: Fil[] // Beholder kun filnavn-feltet ved serialisering
+    innsendelsesfrist: string | undefined
 }
 
 export function opprettFormDataMedVedleggFraOppgaver(oppgaver: Oppgave[]): FormData {
@@ -14,6 +15,7 @@ export function opprettFormDataMedVedleggFraOppgaver(oppgaver: Oppgave[]): FormD
             metadata.push({
                 type: oppgaveElement.dokumenttype,
                 tilleggsinfo: oppgaveElement.tilleggsinformasjon,
+                innsendelsesfrist: oppgave.innsendelsesfrist,
                 filer: oppgaveElement.filer ? oppgaveElement.filer : []
             });
         });
@@ -26,7 +28,8 @@ export function opprettFormDataMedVedleggFraFiler(filer: Fil[]): FormData {
         {
             type: "annet",
             tilleggsinfo: "annet",
-            filer: filer
+            filer: filer,
+            innsendelsesfrist : undefined
         }
     ];
     return opprettFormDataMedVedlegg(metadata);
@@ -35,7 +38,7 @@ export function opprettFormDataMedVedleggFraFiler(filer: Fil[]): FormData {
 function opprettFormDataMedVedlegg(metadata: Metadata[]): FormData {
     let formData = new FormData();
     // Metadata skal ikke inneholde file-blob fra Fil-typen
-    const metadataJson = JSON.stringify(metadata, ["type", "tilleggsinfo", "filer", "filnavn"], 8);
+    const metadataJson = JSON.stringify(metadata, ["type", "tilleggsinfo", "innsendelsesfrist", "filer", "filnavn"], 8);
     const metadataBlob = new Blob([metadataJson], {type: 'application/json'});
     formData.append("files", metadataBlob, "metadata.json");
     metadata.forEach((filgruppe: Metadata) => {


### PR DESCRIPTION
Fikser feilmeldinger på filer også når brukeren laster opp i flere oppgaveElementer.

Tidligere ble ikke feilmelding vist dersom et fungerende fil ble lastet opp i ett oppgaveElement mens en feilende fil ble lastet opp i en av oppgaveElementene under.
Passer også på at det fungerer dersom man har flere oppgaver (altså flere frister)
* Lar innsending av vedlegg bruke et nytt API på backend som også tar imot innsendelsesfrist, og returnerer repons som en liste av oppgaveElement, som deretter har en liste med vedlegg.
OppgaveElementet inkluderer innsendelsesfrist for å vite hvilken oppgave vedlegget tilhører, og den inkluderer type og tilleggsinfo så man vet hvilket oppgaveElement vedlegget tilhører.
* Endrer index til å hete vedleggIndex så det er eksplisitt at det er indexen til vedlegget i et oppgaveElement.


**NB: Må vente på at backend blir deployet med nytt endepunkt først:** 
https://github.com/navikt/sosialhjelp-innsyn-api/pull/153