### PR TITLE
Tar i bruk nytt endepunkt i backend for å hente enkeltoppgaver etter opplasting

### DIFF
--- a/src/components/oppgaver/OppgaveView.tsx
+++ b/src/components/oppgaver/OppgaveView.tsx
@@ -4,10 +4,12 @@ import Lenke from "nav-frontend-lenker";
 import UploadFileIcon from "../ikoner/UploadFile";
 import {
     Fil,
-    InnsynsdataActionTypeKeys, InnsynsdataSti,
+    InnsynsdataActionTypeKeys,
+    InnsynsdataSti,
     KommuneResponse,
     Oppgave,
-    OppgaveElement, settRestStatus,
+    OppgaveElement,
+    settRestStatus,
     Vedlegg,
 } from "../../redux/innsynsdata/innsynsdataReducer";
 import VedleggActionsView from "./VedleggActionsView";
@@ -20,9 +22,11 @@ import {InnsynAppState} from "../../redux/reduxTypes";
 import {erOpplastingAvVedleggEnabled} from "../driftsmelding/DriftsmeldingUtilities";
 import {
     hentInnsynsdata,
-    innsynsdataUrl, logErrorMessage,
+    innsynsdataUrl,
+    logErrorMessage,
     logInfoMessage,
-    setOppgaveVedleggopplastingFeilet
+    setOppgaveVedleggopplastingFeilet,
+    hentOppgaveMedId,
 } from "../../redux/innsynsdata/innsynsDataActions";
 import {antallDagerEtterFrist} from "./Oppgaver";
 import {formatDato} from "../../utils/formatting";
@@ -32,7 +36,9 @@ import {
     legalFileSize,
     legalFileExtension,
     FilFeil,
-    validerFilArrayForFeil, opprettFormDataMedVedleggFraOppgaver, maxMengdeStorrelse,
+    validerFilArrayForFeil,
+    opprettFormDataMedVedleggFraOppgaver,
+    maxMengdeStorrelse,
 } from "../../utils/vedleggUtils";
 import {Hovedknapp} from "nav-frontend-knapper";
 import {fetchPost, REST_STATUS} from "../../utils/restUtils";
@@ -76,19 +82,19 @@ const feilmeldingComponentTittel = (feilId: string, filnavn: string, listeMedFil
     if (listeMedFil.length > 1) {
         return (
             <div className="oppgaver_vedlegg_feilmelding_overskrift">
-                <FormattedMessage id={feilId} values={{antallFiler: listeMedFil.length}}/>
+                <FormattedMessage id={feilId} values={{antallFiler: listeMedFil.length}} />
             </div>
         );
     } else if (listeMedFil.length === 1) {
         return (
             <div className="oppgaver_vedlegg_feilmelding_overskrift">
-                <FormattedMessage id={feilId} values={{filnavn: filnavn}}/>
+                <FormattedMessage id={feilId} values={{filnavn: filnavn}} />
             </div>
         );
     } else {
         return (
             <div className="oppgaver_vedlegg_feilmelding_overskrift">
-                <FormattedMessage id={feilId}/>
+                <FormattedMessage id={feilId} />
             </div>
         );
     }
@@ -99,7 +105,7 @@ const feilmeldingComponent = (feilId: string) => {
         <div className="oppgaver_vedlegg_feilmelding">
             <li>
                 <span className="oppgaver_vedlegg_feilmelding_bullet_point">
-                    <FormattedMessage id={feilId}/>
+                    <FormattedMessage id={feilId} />
                 </span>
             </li>
         </div>
@@ -112,7 +118,7 @@ function returnFeilmeldingComponent(flagg: any, filnavn: any, listeMedFil: any) 
             {flagg.ulovligFil && feilmeldingComponentTittel("vedlegg.ulovlig_en_fil_feilmelding", filnavn, listeMedFil)}
             {flagg.ulovligFiler && feilmeldingComponentTittel("vedlegg.ulovlig_flere_fil_feilmelding", "", listeMedFil)}
             {flagg.maxSammensattFilStorrelse &&
-            feilmeldingComponentTittel("vedlegg.ulovlig_storrelse_av_alle_valgte_filer", "", listeMedFil)}
+                feilmeldingComponentTittel("vedlegg.ulovlig_storrelse_av_alle_valgte_filer", "", listeMedFil)}
             {flagg.containsUlovligeTegn && feilmeldingComponent("vedlegg.ulovlig_filnavn_feilmelding")}
             {flagg.legalFileExtension && feilmeldingComponent("vedlegg.ulovlig_filtype_feilmelding")}
             {flagg.maxFilStorrelse && feilmeldingComponent("vedlegg.ulovlig_filstorrelse_feilmelding")}
@@ -229,21 +235,16 @@ export function sjekkerFilFeil(
 function harIkkeValgtFiler(oppgave: Oppgave | null) {
     let antall = 0;
     oppgave &&
-    oppgave.oppgaveElementer.forEach((oppgaveElement: OppgaveElement) => {
-        oppgaveElement.filer &&
-        oppgaveElement.filer.forEach(() => {
-            antall += 1;
+        oppgave.oppgaveElementer.forEach((oppgaveElement: OppgaveElement) => {
+            oppgaveElement.filer &&
+                oppgaveElement.filer.forEach(() => {
+                    antall += 1;
+                });
         });
-    });
     return antall === 0;
 }
 
-
-const OppgaveView: React.FC<Props> = ({
-                                          oppgave,
-                                          oppgaverErFraInnsyn,
-                                          oppgaveIndex,
-                                      }) => {
+const OppgaveView: React.FC<Props> = ({oppgave, oppgaverErFraInnsyn, oppgaveIndex}) => {
     const dispatch = useDispatch();
     const [listeMedFil, setListeMedFil] = useState<Array<FilFeil>>([]);
     const oppgaveVedlegsOpplastingFeilet: boolean = useSelector(
@@ -262,7 +263,6 @@ const OppgaveView: React.FC<Props> = ({
         otherRestStatus === REST_STATUS.INITIALISERT || otherRestStatus === REST_STATUS.PENDING;
 
     const fiksDigisosId: string | undefined = useSelector((state: InnsynAppState) => state.innsynsdata.fiksDigisosId);
-
 
     const onLinkClicked = (
         oppgaveElementIndex: number,
@@ -318,7 +318,6 @@ const OppgaveView: React.FC<Props> = ({
         event.preventDefault();
     };
 
-
     const sendVedlegg = (event: any) => {
         if (!oppgave || !fiksDigisosId) {
             event.preventDefault();
@@ -338,15 +337,15 @@ const OppgaveView: React.FC<Props> = ({
         // dette funger, men foreløpig vises ikke en feilmelding
         function setterStorrelse(oppgave: Oppgave) {
             let sammensattFilStorrelse = 0;
-                oppgave.oppgaveElementer.forEach((oppgaveElement: OppgaveElement) => {
-                    if (oppgaveElement.filer) {
-                        oppgaveElement.filer.forEach((file: Fil) => {
-                            if (file.file?.size) {
-                                sammensattFilStorrelse += file.file.size;
-                            }
-                        });
-                    }
-                });
+            oppgave.oppgaveElementer.forEach((oppgaveElement: OppgaveElement) => {
+                if (oppgaveElement.filer) {
+                    oppgaveElement.filer.forEach((file: Fil) => {
+                        if (file.file?.size) {
+                            sammensattFilStorrelse += file.file.size;
+                        }
+                    });
+                }
+            });
             return sammensattFilStorrelse;
         }
 
@@ -383,7 +382,7 @@ const OppgaveView: React.FC<Props> = ({
                     if (harFeil) {
                         dispatch(settRestStatus(InnsynsdataSti.OPPGAVER, REST_STATUS.FEILET));
                     } else {
-                        dispatch(hentInnsynsdata(fiksDigisosId, InnsynsdataSti.OPPGAVER));
+                        dispatch(hentOppgaveMedId(fiksDigisosId, InnsynsdataSti.OPPGAVER, oppgave.oppgaveId));
                         dispatch(hentInnsynsdata(fiksDigisosId, InnsynsdataSti.HENDELSER));
                         dispatch(hentInnsynsdata(fiksDigisosId, InnsynsdataSti.VEDLEGG));
                     }
@@ -397,8 +396,6 @@ const OppgaveView: React.FC<Props> = ({
         }
         event.preventDefault();
     };
-
-
 
     function velgFil(
         typeTekst: string,
@@ -434,7 +431,7 @@ const OppgaveView: React.FC<Props> = ({
                             }}
                         >
                             <Element>
-                                <FormattedMessage id="vedlegg.velg_fil"/>
+                                <FormattedMessage id="vedlegg.velg_fil" />
                             </Element>
                         </Lenke>
                         <input
@@ -459,8 +456,13 @@ const OppgaveView: React.FC<Props> = ({
         oppgaveElementIndex: number,
         oppgaveIndex: number
     ): JSX.Element {
-        const listeMedFeilForOppgaveElementIndex = listeMedFil.filter(value => value.oppgaveElemendIndex === oppgaveElementIndex);
-        const visOppgaverDetaljeFeil: boolean = oppgaveVedlegsOpplastingFeilet || opplastingFeilet !== undefined || listeMedFeilForOppgaveElementIndex.length > 0;
+        const listeMedFeilForOppgaveElementIndex = listeMedFil.filter(
+            (value) => value.oppgaveElemendIndex === oppgaveElementIndex
+        );
+        const visOppgaverDetaljeFeil: boolean =
+            oppgaveVedlegsOpplastingFeilet ||
+            opplastingFeilet !== undefined ||
+            listeMedFeilForOppgaveElementIndex.length > 0;
         return (
             <div
                 key={oppgaveElementIndex}
@@ -469,30 +471,30 @@ const OppgaveView: React.FC<Props> = ({
                 {velgFil(typeTekst, tilleggsinfoTekst, oppgaveElement, oppgaveElementIndex, oppgaveIndex)}
 
                 {oppgaveElement.vedlegg &&
-                oppgaveElement.vedlegg.length > 0 &&
-                oppgaveElement.vedlegg.map((vedlegg: Vedlegg, vedleggIndex: number) => (
-                    <VedleggActionsView vedlegg={vedlegg} key={vedleggIndex}/>
-                ))}
+                    oppgaveElement.vedlegg.length > 0 &&
+                    oppgaveElement.vedlegg.map((vedlegg: Vedlegg, vedleggIndex: number) => (
+                        <VedleggActionsView vedlegg={vedlegg} key={vedleggIndex} />
+                    ))}
 
                 {oppgaveElement.filer &&
-                oppgaveElement.filer.length > 0 &&
-                oppgaveElement.filer.map((fil: Fil, vedleggIndex: number) => (
-                    <FilView
-                        key={vedleggIndex}
-                        fil={fil}
-                        oppgaveElement={oppgaveElement}
-                        vedleggIndex={vedleggIndex}
-                        oppgaveElementIndex={oppgaveElementIndex}
-                        oppgaveIndex={oppgaveIndex}
-                    />
-                ))}
+                    oppgaveElement.filer.length > 0 &&
+                    oppgaveElement.filer.map((fil: Fil, vedleggIndex: number) => (
+                        <FilView
+                            key={vedleggIndex}
+                            fil={fil}
+                            oppgaveElement={oppgaveElement}
+                            vedleggIndex={vedleggIndex}
+                            oppgaveElementIndex={oppgaveElementIndex}
+                            oppgaveIndex={oppgaveIndex}
+                        />
+                    ))}
                 {validerFilArrayForFeil(listeMedFil) && skrivFeilmelding(listeMedFil, oppgaveElementIndex)}
             </div>
         );
     }
 
     const visOppgaverDetaljeFeiler: boolean =
-        (oppgaveVedlegsOpplastingFeilet || opplastingFeilet !== undefined || listeMedFil.length > 0);
+        oppgaveVedlegsOpplastingFeilet || opplastingFeilet !== undefined || listeMedFil.length > 0;
     return (
         <div>
             <div
@@ -541,11 +543,11 @@ const OppgaveView: React.FC<Props> = ({
                             sendVedlegg(event);
                         }}
                     >
-                        <FormattedMessage id="oppgaver.send_knapp_tittel"/>
+                        <FormattedMessage id="oppgaver.send_knapp_tittel" />
                     </Hovedknapp>
                 )}
             </div>
-            {(oppgaveVedlegsOpplastingFeilet || opplastingFeilet)  && (
+            {(oppgaveVedlegsOpplastingFeilet || opplastingFeilet) && (
                 <div className="oppgaver_vedlegg_feilmelding" style={{marginBottom: "1rem"}}>
                     <FormattedMessage
                         id={

--- a/src/components/oppgaver/Oppgaver.tsx
+++ b/src/components/oppgaver/Oppgaver.tsx
@@ -5,9 +5,7 @@ import DokumentBinder from "../ikoner/DocumentBinder";
 import "./oppgaver.less";
 import {EkspanderbartpanelBase} from "nav-frontend-ekspanderbartpanel";
 import OppgaveView from "./OppgaveView";
-import {
-    Oppgave,
-} from "../../redux/innsynsdata/innsynsdataReducer";
+import {Oppgave} from "../../redux/innsynsdata/innsynsdataReducer";
 import Lastestriper from "../lastestriper/Lasterstriper";
 import {FormattedMessage} from "react-intl";
 import DriftsmeldingVedlegg from "../driftsmelding/DriftsmeldingVedlegg";

--- a/src/redux/innsynsdata/innsynsDataActions.ts
+++ b/src/redux/innsynsdata/innsynsDataActions.ts
@@ -8,6 +8,7 @@ import {
     oppdaterSaksdetaljerState,
     settRestStatus,
     skalViseFeilside,
+    oppdaterOppgaveState,
 } from "./innsynsdataReducer";
 
 export const innsynsdataUrl = (fiksDigisosId: string, sti: string): string => `/innsyn/${fiksDigisosId}/${sti}`;
@@ -19,6 +20,27 @@ export function hentInnsynsdata(fiksDigisosId: string | string, sti: Innsynsdata
         fetchToJson(url)
             .then((response: any) => {
                 dispatch(oppdaterInnsynsdataState(sti, response));
+                dispatch(settRestStatus(sti, REST_STATUS.OK));
+            })
+            .catch((reason) => {
+                if (reason.message === HttpStatus.UNAUTHORIZED) {
+                    dispatch(settRestStatus(sti, REST_STATUS.UNAUTHORIZED));
+                } else {
+                    logErrorMessage(reason.message);
+                    dispatch(settRestStatus(sti, REST_STATUS.FEILET));
+                    dispatch(skalViseFeilside(true));
+                }
+            });
+    };
+}
+
+export function hentOppgaveMedId(fiksDigisosId: string, sti: InnsynsdataSti, oppgaveId: string) {
+    return (dispatch: Dispatch) => {
+        dispatch(settRestStatus(sti, REST_STATUS.PENDING));
+        const url = `${innsynsdataUrl(fiksDigisosId, sti)}/${oppgaveId}`;
+        fetchToJson(url)
+            .then((response: any) => {
+                dispatch(oppdaterOppgaveState(oppgaveId, response));
                 dispatch(settRestStatus(sti, REST_STATUS.OK));
             })
             .catch((reason) => {

--- a/src/redux/innsynsdata/innsynsdataReducer.test.ts
+++ b/src/redux/innsynsdata/innsynsdataReducer.test.ts
@@ -1,49 +1,31 @@
-import React from "react";
-
-// import InnsynsdataReducer, {
-//     InnsynsdataActionType,
-//     InnsynsdataActionTypeKeys,
-//     InnsynsdataSti
-// } from "./innsynsdataReducer";
-// import {REST_STATUS} from "../../utils/restUtils";
+import InnsynsdataReducer, {oppdaterOppgaveState, initialState} from "./innsynsdataReducer";
 
 describe("Innsynsdata reducer", () => {
-    it("should place files in the redux state tree", () => {
-        // const reducer = InnsynsdataReducer;
-        // const action: InnsynsdataActionType = {
-        //     type: InnsynsdataActionTypeKeys.SETT_REST_STATUS,
-        //     sti: InnsynsdataSti.VEDLEGG,
-        //     restStatus: REST_STATUS.OK
-        // };
-        // const defaultState = reducer(undefined, action);
+    it("should handle OPPDATER_OPPGAVE_STATE with empty value", () => {
+        const eksisterendeOppgave = {innsendelsesfrist: "2020-01-01", oppgaveId: "oppgaveId1", oppgaveElementer: []};
+        const action = oppdaterOppgaveState(eksisterendeOppgave.oppgaveId, []);
 
-        expect(1).toBe(1);
-        // const oppgaver = {
-        //     "0": {
-        //         "innsendelsesfrist": "2018-10-20T07:37:00.134",
-        //             "dokumenttype": "Strømfaktura",
-        //             "tilleggsinformasjon": "For periode 01.01.2019 til 01.02.2019"
-        //     },
-        //     "1": {
-        //         "innsendelsesfrist": "2018-10-20T07:37:30",
-        //             "dokumenttype": "Kopi av depositumskonto",
-        //             "tilleggsinformasjon": "Signert av både deg og utleier"
-        //     }
-        // };
-        //
-        // Object.entries(oppgaver).map((entry) => {
-        //     const oppgave: Oppgave = entry[1];
-        //     if (oppgave.dokumenttype === "Strømfaktura") {
-        //         oppgave.filer = [1,2,3];
-        //     }
-        // });
-        //
-        // // spike converting map to array
-        // const oppgaverArray = Object.entries(oppgaver).map((value) => value[1]);
-        //
-        // console.warn(JSON.stringify(oppgaver, null, 8));
-        // expect(oppgaverArray[0].dokumenttype).toBe("Strømfaktura");
+        const initialStateMedOppgaver = {
+            ...initialState,
+            oppgaver: [eksisterendeOppgave],
+        };
+
+        expect(InnsynsdataReducer(initialStateMedOppgaver, action)).toEqual({...initialStateMedOppgaver, oppgaver: []});
     });
 
-    // if('should handle action')
+    it("should handle OPPDATER_OPPGAVE_STATE with new and existing values", () => {
+        const eksisterendeOppgave1 = {innsendelsesfrist: "2020-01-01", oppgaveId: "oppgaveId1", oppgaveElementer: []};
+        const eksisterendeOppgave2 = {innsendelsesfrist: "2020-01-01", oppgaveId: "oppgaveId2", oppgaveElementer: []};
+        const action = oppdaterOppgaveState("oppgaveId1", []);
+
+        const initialStateMedOppgaver = {
+            ...initialState,
+            oppgaver: [eksisterendeOppgave1, eksisterendeOppgave2],
+        };
+
+        expect(InnsynsdataReducer(initialStateMedOppgaver, action)).toEqual({
+            ...initialStateMedOppgaver,
+            oppgaver: [eksisterendeOppgave2],
+        });
+    });
 });

--- a/src/redux/innsynsdata/innsynsdataReducer.ts
+++ b/src/redux/innsynsdata/innsynsdataReducer.ts
@@ -66,6 +66,7 @@ export interface Fil {
 
 export interface Oppgave {
     innsendelsesfrist?: string;
+    oppgaveId: string;
     oppgaveElementer: OppgaveElement[];
 }
 
@@ -81,6 +82,7 @@ export enum InnsynsdataActionTypeKeys {
     // Innsynsdata:
     SETT_FIKSDIGISOSID = "innsynsdata/SETT_FIKSDIGISOSID",
     OPPDATER_INNSYNSSDATA_STI = "innsynsdata/OPPDATER_STI",
+    OPPDATER_OPPGAVE_STATE = "innsynsdata/OPPDATER_OPPGAVE_STATE",
     SETT_REST_STATUS = "innsynsdata/SETT_REST_STATUS",
     SKAL_VISE_FEILSIDE = "innsynsdata/SKAL_VISE_FEILSIDE",
 
@@ -114,6 +116,7 @@ export interface InnsynsdataActionType {
     sti: InnsynsdataSti;
     restStatus?: string;
     skalVise?: boolean;
+    oppgaveId?: string;
 }
 
 export interface VedleggActionType {
@@ -204,7 +207,7 @@ export const initialInnsynsdataRestStatus = {
     kommune: REST_STATUS.INITIALISERT,
 };
 
-const initialState: InnsynsdataType = {
+export const initialState: InnsynsdataType = {
     fiksDigisosId: undefined,
     saksStatus: [],
     oppgaver: [],
@@ -250,6 +253,23 @@ const InnsynsdataReducer: Reducer<
         case InnsynsdataActionTypeKeys.OPPDATER_INNSYNSSDATA_STI:
             return {
                 ...setPath(state, action.sti, action.verdi),
+            };
+        case InnsynsdataActionTypeKeys.OPPDATER_OPPGAVE_STATE:
+            const oppgave: Oppgave[] = action.verdi;
+            if (oppgave.length === 0) {
+                return {
+                    ...state,
+                    oppgaver: state.oppgaver.filter((oppgave: Oppgave) => oppgave.oppgaveId !== action.oppgaveId),
+                };
+            }
+            return {
+                ...state,
+                oppgaver: state.oppgaver.map((oppgave) => {
+                    if (oppgave.oppgaveId === action.oppgaveId) {
+                        return action.verdi[0];
+                    }
+                    return oppgave;
+                }),
             };
         case InnsynsdataActionTypeKeys.SETT_REST_STATUS:
             return {
@@ -460,6 +480,15 @@ export const oppdaterInnsynsdataState = (sti: InnsynsdataSti, verdi: any): Innsy
     return {
         type: InnsynsdataActionTypeKeys.OPPDATER_INNSYNSSDATA_STI,
         sti,
+        verdi,
+    };
+};
+
+export const oppdaterOppgaveState = (oppgaveId: string, verdi: Oppgave[]): any => {
+    return {
+        type: InnsynsdataActionTypeKeys.OPPDATER_OPPGAVE_STATE,
+        sti: InnsynsdataSti.OPPGAVER,
+        oppgaveId,
         verdi,
     };
 };


### PR DESCRIPTION
Ved opplasting av vedlegg gjør vi nye kall mot backend for å hente ut oppdatert state for oppgaver. Denne staten overskriver det vi har under "oppgaver" i appen vår allerede, og fører til at brukere som eks. har lagt til filer for opplasting under flere oppgaver mister disse når hen trykker på "Last opp".

Ved å kun hente oppdatert state for den oppgaven vi har lastet opp filer til, slipper vi å oppdatere state for de andre oppgavene.

https://github.com/navikt/sosialhjelp-innsyn-api/pull/170 må være i prod først, slik at frontend ikke prøver å kalle endepunkter som ikke eksisterer.