### PR TITLE
Flytte hotjar fra landingsside til søknadssiden.

### DIFF
--- a/src/components/hotjarTrigger/HotjarTrigger.js
+++ b/src/components/hotjarTrigger/HotjarTrigger.js
@@ -21,18 +21,26 @@ HotjarTrigger.propTypes = {
     children: node.isRequired,
 };
 
-export const LandingssideMedSakerFraInnsynHotjarTrigger = ({children}) => (
-    <HotjarTrigger hotjarTrigger="landingsside_med_saker_fra_innsyn">{children}</HotjarTrigger>
+export const SoknadMedInnsynHotjarTrigger = ({children}) => (
+    <HotjarTrigger hotjarTrigger="soknad_med_innsyn">{children}</HotjarTrigger>
 );
 
-LandingssideMedSakerFraInnsynHotjarTrigger.propTypes = {
+SoknadMedInnsynHotjarTrigger.propTypes = {
     children: node,
 };
 
-export const LandingssideUtenSakerFraInnsynHotjarTrigger = ({children}) => (
-    <HotjarTrigger hotjarTrigger="landingsside_uten_saker_fra_innsyn">{children}</HotjarTrigger>
+export const SoknadMedInnsynFraBergenHotjarTrigger = ({children}) => (
+    <HotjarTrigger hotjarTrigger="soknad_med_innsyn_fra_bergen">{children}</HotjarTrigger>
 );
 
-LandingssideUtenSakerFraInnsynHotjarTrigger.propTypes = {
+SoknadMedInnsynFraBergenHotjarTrigger.propTypes = {
+    children: node,
+};
+
+export const SoknadUtenInnsynHotjarTrigger = ({children}) => (
+    <HotjarTrigger hotjarTrigger="soknad_uten_innsyn">{children}</HotjarTrigger>
+);
+
+SoknadUtenInnsynHotjarTrigger.propTypes = {
     children: node,
 };

--- a/src/components/hotjarTrigger/HotjarTrigger.js
+++ b/src/components/hotjarTrigger/HotjarTrigger.js
@@ -22,23 +22,23 @@ HotjarTrigger.propTypes = {
 };
 
 export const SoknadMedInnsynHotjarTrigger = ({children}) => (
-    <HotjarTrigger hotjarTrigger="soknad_med_innsyn">{children}</HotjarTrigger>
+    <HotjarTrigger hotjarTrigger="digisos_soknad_med_innsyn">{children}</HotjarTrigger>
 );
 
 SoknadMedInnsynHotjarTrigger.propTypes = {
     children: node,
 };
 
-export const SoknadMedInnsynFraBergenHotjarTrigger = ({children}) => (
-    <HotjarTrigger hotjarTrigger="soknad_med_innsyn_fra_bergen">{children}</HotjarTrigger>
+export const SoknadFraBergenHotjarTrigger = ({children}) => (
+    <HotjarTrigger hotjarTrigger="digisos_soknad_fra_bergen">{children}</HotjarTrigger>
 );
 
-SoknadMedInnsynFraBergenHotjarTrigger.propTypes = {
+SoknadFraBergenHotjarTrigger.propTypes = {
     children: node,
 };
 
 export const SoknadUtenInnsynHotjarTrigger = ({children}) => (
-    <HotjarTrigger hotjarTrigger="soknad_uten_innsyn">{children}</HotjarTrigger>
+    <HotjarTrigger hotjarTrigger="digisos_soknad_uten_innsyn">{children}</HotjarTrigger>
 );
 
 SoknadUtenInnsynHotjarTrigger.propTypes = {

--- a/src/innsyn/SaksStatus.tsx
+++ b/src/innsyn/SaksStatus.tsx
@@ -21,7 +21,12 @@ import Brodsmulesti, {UrlType} from "../components/brodsmuleSti/BrodsmuleSti";
 import {soknadsStatusTittel} from "../components/soknadsStatus/soknadsStatusUtils";
 import {Panel} from "nav-frontend-paneler";
 import {Systemtittel} from "nav-frontend-typografi";
-import {SoknadMedInnsynHotjarTrigger, SoknadUtenInnsynHotjarTrigger} from "../components/hotjarTrigger/HotjarTrigger";
+import {
+    SoknadFraBergenHotjarTrigger,
+    SoknadMedInnsynHotjarTrigger,
+    SoknadUtenInnsynHotjarTrigger,
+} from "../components/hotjarTrigger/HotjarTrigger";
+import {isKommuneBergen, isKommuneMedInnsynUtenBergen, isKommuneUtenInnsynUtenBergen} from "./saksStatusUtils";
 
 interface Props {
     match: {
@@ -84,18 +89,23 @@ const SaksStatusView: React.FC<Props> = ({match}) => {
 
             <DriftsmeldingAlertstripe />
 
-            {kommuneResponse != null && !kommuneResponse.erInnsynDeaktivert && (
+            {isKommuneMedInnsynUtenBergen(kommuneResponse, restStatus.kommune) && (
                 <SoknadMedInnsynHotjarTrigger>
                     <ForelopigSvarAlertstripe />
                 </SoknadMedInnsynHotjarTrigger>
             )}
 
-            {kommuneResponse == null ||
-                (kommuneResponse.erInnsynDeaktivert && (
-                    <SoknadUtenInnsynHotjarTrigger>
-                        <ForelopigSvarAlertstripe />
-                    </SoknadUtenInnsynHotjarTrigger>
-                ))}
+            {isKommuneBergen(kommuneResponse) && (
+                <SoknadFraBergenHotjarTrigger>
+                    <ForelopigSvarAlertstripe />
+                </SoknadFraBergenHotjarTrigger>
+            )}
+
+            {isKommuneUtenInnsynUtenBergen(kommuneResponse, restStatus.kommune) && (
+                <SoknadUtenInnsynHotjarTrigger>
+                    <ForelopigSvarAlertstripe />
+                </SoknadUtenInnsynHotjarTrigger>
+            )}
 
             <SoknadsStatus
                 status={innsynsdata.soknadsStatus.status}

--- a/src/innsyn/SaksStatus.tsx
+++ b/src/innsyn/SaksStatus.tsx
@@ -21,6 +21,7 @@ import Brodsmulesti, {UrlType} from "../components/brodsmuleSti/BrodsmuleSti";
 import {soknadsStatusTittel} from "../components/soknadsStatus/soknadsStatusUtils";
 import {Panel} from "nav-frontend-paneler";
 import {Systemtittel} from "nav-frontend-typografi";
+import {SoknadMedInnsynHotjarTrigger, SoknadUtenInnsynHotjarTrigger} from "../components/hotjarTrigger/HotjarTrigger";
 
 interface Props {
     match: {
@@ -82,7 +83,19 @@ const SaksStatusView: React.FC<Props> = ({match}) => {
             />
 
             <DriftsmeldingAlertstripe />
-            <ForelopigSvarAlertstripe />
+
+            {kommuneResponse != null && !kommuneResponse.erInnsynDeaktivert && (
+                <SoknadMedInnsynHotjarTrigger>
+                    <ForelopigSvarAlertstripe />
+                </SoknadMedInnsynHotjarTrigger>
+            )}
+
+            {kommuneResponse == null ||
+                (kommuneResponse.erInnsynDeaktivert && (
+                    <SoknadUtenInnsynHotjarTrigger>
+                        <ForelopigSvarAlertstripe />
+                    </SoknadUtenInnsynHotjarTrigger>
+                ))}
 
             <SoknadsStatus
                 status={innsynsdata.soknadsStatus.status}

--- a/src/innsyn/saksStatusUtils.test.ts
+++ b/src/innsyn/saksStatusUtils.test.ts
@@ -1,0 +1,124 @@
+import {KommuneResponse} from "../redux/innsynsdata/innsynsdataReducer";
+import {
+    isKommuneBergen,
+    isKommuneInfoFetched,
+    isKommuneMedInnsynUtenBergen,
+    isKommuneUtenInnsynUtenBergen,
+} from "./saksStatusUtils";
+import {REST_STATUS} from "../utils/restUtils";
+
+describe("Hotjar-trigger utils", () => {
+    it("before fetching kommuneResponse, all hotjartriggers should be disabled", () => {
+        const initialKommuneResponse: KommuneResponse = {
+            erInnsynDeaktivert: false,
+            erInnsynMidlertidigDeaktivert: false,
+            erInnsendingEttersendelseDeaktivert: false,
+            erInnsendingEttersendelseMidlertidigDeaktivert: false,
+            tidspunkt: null,
+            kommunenummer: null,
+        };
+
+        // INITIALISERT
+        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
+        expect(isKommuneInfoFetched(REST_STATUS.INITIALISERT)).toBe(false);
+        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.INITIALISERT)).toBe(false);
+        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.INITIALISERT)).toBe(false);
+
+        // PENDING
+        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
+        expect(isKommuneInfoFetched(REST_STATUS.PENDING)).toBe(false);
+        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.PENDING)).toBe(false);
+        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.PENDING)).toBe(false);
+    });
+
+    it("failing kommuneResponse should trigger hotjar utenInnsyn", () => {
+        const initialKommuneResponse: KommuneResponse = {
+            erInnsynDeaktivert: false,
+            erInnsynMidlertidigDeaktivert: false,
+            erInnsendingEttersendelseDeaktivert: false,
+            erInnsendingEttersendelseMidlertidigDeaktivert: false,
+            tidspunkt: null,
+            kommunenummer: null,
+        };
+
+        // FEILET
+        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
+        expect(isKommuneInfoFetched(REST_STATUS.FEILET)).toBe(true);
+        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.FEILET)).toBe(false);
+        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.FEILET)).toBe(true);
+
+        // UNAUTHORIZED
+        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
+        expect(isKommuneInfoFetched(REST_STATUS.UNAUTHORIZED)).toBe(true);
+        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.UNAUTHORIZED)).toBe(false);
+        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.UNAUTHORIZED)).toBe(true);
+
+        // SERVICE_UNAVAILABLE
+        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
+        expect(isKommuneInfoFetched(REST_STATUS.SERVICE_UNAVAILABLE)).toBe(true);
+        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.SERVICE_UNAVAILABLE)).toBe(false);
+        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.SERVICE_UNAVAILABLE)).toBe(true);
+    });
+
+    it("kommunenummer 4601 should trigger hotjar for Bergen", () => {
+        const kommuneResponseBergenAktivert: KommuneResponse = {
+            erInnsynDeaktivert: false,
+            erInnsynMidlertidigDeaktivert: false,
+            erInnsendingEttersendelseDeaktivert: false,
+            erInnsendingEttersendelseMidlertidigDeaktivert: false,
+            tidspunkt: null,
+            kommunenummer: "4601",
+        };
+        const kommuneResponseBergenDeaktivert: KommuneResponse = {
+            erInnsynDeaktivert: true,
+            erInnsynMidlertidigDeaktivert: false,
+            erInnsendingEttersendelseDeaktivert: false,
+            erInnsendingEttersendelseMidlertidigDeaktivert: false,
+            tidspunkt: null,
+            kommunenummer: "4601",
+        };
+        const kommuneRestStatus: REST_STATUS = REST_STATUS.OK;
+
+        expect(isKommuneBergen(kommuneResponseBergenAktivert)).toBe(true);
+        expect(isKommuneInfoFetched(kommuneRestStatus)).toBe(true);
+        expect(isKommuneMedInnsynUtenBergen(kommuneResponseBergenAktivert, kommuneRestStatus)).toBe(false);
+        expect(isKommuneUtenInnsynUtenBergen(kommuneResponseBergenAktivert, kommuneRestStatus)).toBe(false);
+
+        expect(isKommuneBergen(kommuneResponseBergenDeaktivert)).toBe(true);
+        expect(isKommuneInfoFetched(kommuneRestStatus)).toBe(true);
+        expect(isKommuneMedInnsynUtenBergen(kommuneResponseBergenDeaktivert, kommuneRestStatus)).toBe(false);
+        expect(isKommuneUtenInnsynUtenBergen(kommuneResponseBergenDeaktivert, kommuneRestStatus)).toBe(false);
+    });
+
+    it("deaktivert innsyn (and not Bergen), should trigger hotjar utenInnsyn", () => {
+        const kommuneResponse: KommuneResponse = {
+            erInnsynDeaktivert: true,
+            erInnsynMidlertidigDeaktivert: false,
+            erInnsendingEttersendelseDeaktivert: false,
+            erInnsendingEttersendelseMidlertidigDeaktivert: false,
+            tidspunkt: null,
+            kommunenummer: "0001",
+        };
+
+        expect(isKommuneBergen(kommuneResponse)).toBe(false);
+        expect(isKommuneInfoFetched(REST_STATUS.OK)).toBe(true);
+        expect(isKommuneMedInnsynUtenBergen(kommuneResponse, REST_STATUS.OK)).toBe(false);
+        expect(isKommuneUtenInnsynUtenBergen(kommuneResponse, REST_STATUS.OK)).toBe(true);
+    });
+
+    it("aktivert innsyn (and not Bergen), should trigger hotjar medInnsyn", () => {
+        const kommuneResponse: KommuneResponse = {
+            erInnsynDeaktivert: false,
+            erInnsynMidlertidigDeaktivert: false,
+            erInnsendingEttersendelseDeaktivert: false,
+            erInnsendingEttersendelseMidlertidigDeaktivert: false,
+            tidspunkt: null,
+            kommunenummer: "0001",
+        };
+
+        expect(isKommuneBergen(kommuneResponse)).toBe(false);
+        expect(isKommuneInfoFetched(REST_STATUS.OK)).toBe(true);
+        expect(isKommuneMedInnsynUtenBergen(kommuneResponse, REST_STATUS.OK)).toBe(true);
+        expect(isKommuneUtenInnsynUtenBergen(kommuneResponse, REST_STATUS.OK)).toBe(false);
+    });
+});

--- a/src/innsyn/saksStatusUtils.ts
+++ b/src/innsyn/saksStatusUtils.ts
@@ -1,0 +1,43 @@
+import {KommuneResponse} from "../redux/innsynsdata/innsynsdataReducer";
+import {REST_STATUS} from "../utils/restUtils";
+
+const kommunenummerBergen = "4601";
+
+export function isKommuneInfoFetched(kommuneRestStatus: REST_STATUS): boolean {
+    return kommuneRestStatus !== REST_STATUS.INITIALISERT && kommuneRestStatus !== REST_STATUS.PENDING;
+}
+
+export function isKommuneInfoFeilet(kommuneRestStatus: REST_STATUS): boolean {
+    return (
+        kommuneRestStatus === REST_STATUS.FEILET ||
+        kommuneRestStatus === REST_STATUS.UNAUTHORIZED ||
+        kommuneRestStatus === REST_STATUS.SERVICE_UNAVAILABLE
+    );
+}
+
+export function isKommuneBergen(kommuneResponse: KommuneResponse | undefined): boolean {
+    return kommuneResponse != null && kommuneResponse.kommunenummer === kommunenummerBergen;
+}
+
+export function isKommuneMedInnsynUtenBergen(
+    kommuneResponse: KommuneResponse | undefined,
+    kommuneRestStatus: REST_STATUS
+): boolean {
+    return (
+        kommuneResponse != null &&
+        !kommuneResponse.erInnsynDeaktivert &&
+        !isKommuneBergen(kommuneResponse) &&
+        kommuneRestStatus === REST_STATUS.OK
+    );
+}
+
+export function isKommuneUtenInnsynUtenBergen(
+    kommuneResponse: KommuneResponse | undefined,
+    kommuneRestStatus: REST_STATUS
+): boolean {
+    return (
+        (kommuneResponse == null || kommuneResponse.erInnsynDeaktivert || isKommuneInfoFeilet(kommuneRestStatus)) &&
+        !isKommuneBergen(kommuneResponse) &&
+        isKommuneInfoFetched(kommuneRestStatus)
+    );
+}

--- a/src/redux/innsynsdata/innsynsdataReducer.ts
+++ b/src/redux/innsynsdata/innsynsdataReducer.ts
@@ -172,6 +172,7 @@ export interface KommuneResponse {
     erInnsendingEttersendelseDeaktivert: boolean;
     erInnsendingEttersendelseMidlertidigDeaktivert: boolean;
     tidspunkt: Date | null;
+    kommunenummer: String | null;
 }
 
 const initiellKommuneResponse_antarAltOk: KommuneResponse = {
@@ -180,6 +181,7 @@ const initiellKommuneResponse_antarAltOk: KommuneResponse = {
     erInnsendingEttersendelseDeaktivert: false,
     erInnsendingEttersendelseMidlertidigDeaktivert: false,
     tidspunkt: null,
+    kommunenummer: null,
 };
 
 export interface InnsynsdataType {

--- a/src/saksoversikt/Saksoversikt.tsx
+++ b/src/saksoversikt/Saksoversikt.tsx
@@ -11,10 +11,6 @@ import BigBanner from "../components/banner/BigBanner";
 import useSoknadsSakerService from "./sakerFraSoknad/useSoknadsSakerService";
 import {useBannerTittel} from "../redux/navigasjon/navigasjonUtils";
 import {AlertStripeAdvarsel} from "nav-frontend-alertstriper";
-import {
-    LandingssideMedSakerFraInnsynHotjarTrigger,
-    LandingssideUtenSakerFraInnsynHotjarTrigger,
-} from "../components/hotjarTrigger/HotjarTrigger";
 import SaksoversiktIngenSoknader from "./SaksoversiktIngenSoknader";
 
 const Saksoversikt: React.FC = () => {
@@ -78,16 +74,7 @@ const Saksoversikt: React.FC = () => {
                                 mangler i listen under, ber vi deg vennligst prøve igjen senere.
                             </AlertStripeAdvarsel>
                         )}
-                        {harSaker && harSakerMedStatusFraInnsyn && (
-                            <LandingssideMedSakerFraInnsynHotjarTrigger>
-                                <SaksoversiktDineSaker saker={alleSaker} />
-                            </LandingssideMedSakerFraInnsynHotjarTrigger>
-                        )}
-                        {harSaker && !harSakerMedStatusFraInnsyn && (
-                            <LandingssideUtenSakerFraInnsynHotjarTrigger>
-                                <SaksoversiktDineSaker saker={alleSaker} />
-                            </LandingssideUtenSakerFraInnsynHotjarTrigger>
-                        )}
+                        {harSaker && <SaksoversiktDineSaker saker={alleSaker} />}
                         {!harSaker && <SaksoversiktIngenSoknader />}
                     </>
                 )}

--- a/src/saksoversikt/Saksoversikt.tsx
+++ b/src/saksoversikt/Saksoversikt.tsx
@@ -47,7 +47,6 @@ const Saksoversikt: React.FC = () => {
         }
     }
     const harSaker = alleSaker.length > 0;
-    const harSakerMedStatusFraInnsyn = saker.length > 0 && saker.some((sakstype) => sakstype.status !== "");
 
     useEffect(() => {
         dispatch(hentSaksdata(InnsynsdataSti.SAKER));


### PR DESCRIPTION
Endrer også triggernavn (sjekker med Wilhelm først)
Klargjør også en egen trigger for Bergen, som vi ønsker å ha i overgangen når vi går fra å kun ha Bergen på innsyn til å også få nye kommuner. Må vente på at backend sender kommunenummer i /kommune først

Edgecaser:
Dersom kommuneinfo ikke blir hentet korrekt antar vi at kommunen ikke er på innsyn.
Dersom kommunen har innsyn midlertidig deaktivert, bruker vi hotjartriggeren medInnsyn