### PR TITLE
Fikser sirkulær avhengighet mellom restUtils.ts og innsynsDataActions.ts

### DIFF
--- a/src/components/oppgaver/OppgaveView.tsx
+++ b/src/components/oppgaver/OppgaveView.tsx
@@ -23,8 +23,6 @@ import {erOpplastingAvVedleggTillat} from "../driftsmelding/DriftsmeldingUtiliti
 import {
     hentInnsynsdata,
     innsynsdataUrl,
-    logErrorMessage,
-    logInfoMessage,
     setOppgaveVedleggopplastingFeilet,
     hentOppgaveMedId,
     setOppgaveOpplastingFeilet,
@@ -44,6 +42,7 @@ import {
 } from "../../utils/vedleggUtils";
 import {Hovedknapp} from "nav-frontend-knapper";
 import {fetchPost, REST_STATUS} from "../../utils/restUtils";
+import {logErrorMessage, logInfoMessage} from "../../redux/innsynsdata/loggActions";
 
 interface Props {
     oppgave: Oppgave;

--- a/src/components/vedlegg/EttersendelseView.tsx
+++ b/src/components/vedlegg/EttersendelseView.tsx
@@ -17,7 +17,6 @@ import {InnsynAppState} from "../../redux/reduxTypes";
 import {
     hentInnsynsdata,
     innsynsdataUrl,
-    logErrorMessage,
     setOppgaveOpplastingFeiletPaBackend,
 } from "../../redux/innsynsdata/innsynsDataActions";
 import {fetchPost, REST_STATUS} from "../../utils/restUtils";
@@ -30,6 +29,7 @@ import {
 import {skrivFeilmelding, finnFilerMedFeil} from "../oppgaver/OppgaveView";
 import {erOpplastingAvVedleggTillat} from "../driftsmelding/DriftsmeldingUtilities";
 import DriftsmeldingVedlegg from "../driftsmelding/DriftsmeldingVedlegg";
+import {logErrorMessage} from "../../redux/innsynsdata/loggActions";
 
 function harFilermedFeil(filer: Fil[]) {
     return filer.find((it) => {

--- a/src/redux/innsynsdata/innsynsDataActions.ts
+++ b/src/redux/innsynsdata/innsynsDataActions.ts
@@ -1,5 +1,5 @@
 import {Dispatch} from "redux";
-import {fetchToJson, HttpStatus, REST_STATUS, fetchPost} from "../../utils/restUtils";
+import {fetchToJson, HttpStatus, REST_STATUS} from "../../utils/restUtils";
 import {
     InnsynsdataActionTypeKeys,
     InnsynsdataSti,
@@ -10,6 +10,7 @@ import {
     skalViseFeilside,
     oppdaterOppgaveState,
 } from "./innsynsdataReducer";
+import {logErrorMessage} from "./loggActions";
 
 export const innsynsdataUrl = (fiksDigisosId: string, sti: string): string => `/innsyn/${fiksDigisosId}/${sti}`;
 
@@ -101,39 +102,6 @@ export function hentSaksdetaljer(fiksDigisosId: string, visFeilSide?: boolean) {
             });
     };
 }
-
-const LOG_URL = "/info/logg";
-
-export function logInfoMessage(message: string, navCallId?: string) {
-    fetchPost(LOG_URL, JSON.stringify(createLogEntry(message, "INFO", navCallId)))
-        .then(() => {})
-        .catch(() => {
-            return; // Not important to handle those errors
-        });
-}
-
-export function logErrorMessage(message: string, navCallId?: string) {
-    fetchPost(LOG_URL, JSON.stringify(createLogEntry(message, "ERROR", navCallId)))
-        .then(() => {})
-        .catch(() => {
-            return; // Not important to handle those errors
-        });
-}
-
-function createLogEntry(message: string, level: LogLevel, navCallId?: string) {
-    return {
-        level: level,
-        message: message,
-        jsFileUrl: "",
-        lineNumber: "",
-        columnNumber: "",
-        url: window.location.href,
-        userAgent: window.navigator.userAgent,
-        loggenGjelderForCallId: navCallId,
-    };
-}
-
-type LogLevel = "ERROR" | "WARN" | "INFO";
 
 export const setOppgaveVedleggopplastingFeilet = (status: boolean) => ({
     type: InnsynsdataActionTypeKeys.OPPGAVE_VEDLEGSOPPLASTING_FEILET,

--- a/src/redux/innsynsdata/loggActions.ts
+++ b/src/redux/innsynsdata/loggActions.ts
@@ -1,0 +1,34 @@
+import {fetchPost} from "../../utils/restUtils";
+
+const LOG_URL = "/info/logg";
+
+export function logInfoMessage(message: string, navCallId?: string) {
+    fetchPost(LOG_URL, JSON.stringify(createLogEntry(message, "INFO", navCallId)))
+        .then(() => {})
+        .catch(() => {
+            return; // Not important to handle those errors
+        });
+}
+
+export function logErrorMessage(message: string, navCallId?: string) {
+    fetchPost(LOG_URL, JSON.stringify(createLogEntry(message, "ERROR", navCallId)))
+        .then(() => {})
+        .catch(() => {
+            return; // Not important to handle those errors
+        });
+}
+
+function createLogEntry(message: string, level: LogLevel, navCallId?: string) {
+    return {
+        level: level,
+        message: message,
+        jsFileUrl: "",
+        lineNumber: "",
+        columnNumber: "",
+        url: window.location.href,
+        userAgent: window.navigator.userAgent,
+        loggenGjelderForCallId: navCallId,
+    };
+}
+
+type LogLevel = "ERROR" | "WARN" | "INFO";

--- a/src/utbetalinger/service/useUtbetalingerService.ts
+++ b/src/utbetalinger/service/useUtbetalingerService.ts
@@ -1,7 +1,7 @@
 import {useEffect, useState} from "react";
 import {fetchToJson, REST_STATUS} from "../../utils/restUtils";
 import {ServiceHookTypes} from "../../utils/ServiceHookTypes";
-import {logErrorMessage} from "../../redux/innsynsdata/innsynsDataActions";
+import {logErrorMessage} from "../../redux/innsynsdata/loggActions";
 
 export interface UtbetalingType {
     tittel: string;

--- a/src/utils/restUtils.ts
+++ b/src/utils/restUtils.ts
@@ -1,6 +1,6 @@
 import "whatwg-fetch";
-import {logErrorMessage} from "../redux/innsynsdata/innsynsDataActions";
 import uuid from "uuid";
+import {logErrorMessage} from "../redux/innsynsdata/loggActions";
 
 export function erDev(): boolean {
     const url = window.location.href;

--- a/src/utils/vedleggUtils.ts
+++ b/src/utils/vedleggUtils.ts
@@ -1,5 +1,5 @@
 import {Fil, Oppgave, OppgaveElement} from "../redux/innsynsdata/innsynsdataReducer";
-import {logInfoMessage} from "../redux/innsynsdata/innsynsDataActions";
+import {logInfoMessage} from "../redux/innsynsdata/loggActions";
 
 export const maxMengdeStorrelse = 150 * 1024 * 1024;
 export const maxFilStorrelse = 10 * 1024 * 1024;


### PR DESCRIPTION
Tidligere var det en sirkulær avhengighet, 
- der **restUtils.ts** hentet **logErrorMessage** fra **innsynsDataActions.ts**
- og **innsynsDataActions.ts** hentete **REST_STATUS** fra **restUtils.ts**

Dette gjorde blandt annet at tester man ønsker å lage med en import fra en av disse vil faile. Generelt kan sirkulære avhengigheter også få uventede konsekvenser.

Fikset det ved å dra **loggActions.ts** ut fra **innsynsDataActions.ts** slik at **restUtils.ts** ikke lenger har en avhengighet til **innsynsDataActions.ts**