### PR TITLE
Kjører opp applikasjonen på port 3002.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open [http://localhost:3000](http://localhost:3002) to view it in the browser.
 
 The page will reload if you make edits.<br>
 You will also see any lint errors in the console.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3002) to view it in the browser.
+Open [http://localhost:3002](http://localhost:3002) to view it in the browser.
 
 The page will reload if you make edits.<br>
 You will also see any lint errors in the console.

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "node start.js",
     "build": "craco build",
     "test": "craco test",
     "eject": "react-scripts eject"

--- a/src/components/nySoknadModal/service/ServiceHookTypes.ts
+++ b/src/components/nySoknadModal/service/ServiceHookTypes.ts
@@ -22,5 +22,5 @@ export type ServiceHookTypes<T> = ServiceInit | ServiceLoading | ServiceLoaded<T
 
 export const erDevMiljo = (): boolean => {
     const url = window.location.href;
-    return url.indexOf("localhost:3000") > 0;
+    return url.indexOf("localhost:") > 0;
 };

--- a/src/utils/ServiceHookTypes.ts
+++ b/src/utils/ServiceHookTypes.ts
@@ -22,5 +22,5 @@ export type ServiceHookTypes<T> = ServiceInit | ServiceLoading | ServiceLoaded<T
 
 export const erDevMiljo = (): boolean => {
     const url = window.location.href;
-    return url.indexOf("localhost:3000") > 0;
+    return url.indexOf("localhost:") > 0;
 };

--- a/src/utils/restUtils.ts
+++ b/src/utils/restUtils.ts
@@ -4,7 +4,7 @@ import {logErrorMessage} from "../redux/innsynsdata/loggActions";
 
 export function erDev(): boolean {
     const url = window.location.href;
-    return url.indexOf("localhost:3000") > 0;
+    return url.indexOf("localhost:") > 0;
 }
 
 export function erQ(): boolean {

--- a/start.js
+++ b/start.js
@@ -1,0 +1,12 @@
+var os = require('os');
+var exec = require('child_process').exec;
+
+var runString = "";
+console.log("Du kjører på OS: " + os.type())
+if (os.type() === 'Windows_NT')
+    runString = "set PORT=3002 && craco start";
+else
+    runString = "PORT=3002 craco start";
+
+exec(runString);
+console.log("Starter med commando: " + runString);

--- a/start.js
+++ b/start.js
@@ -2,11 +2,23 @@ var os = require('os');
 var exec = require('child_process').exec;
 
 var runString = "";
-console.log("Du kjører på OS: " + os.type())
+console.log("Ditt OS er " + os.type())
 if (os.type() === 'Windows_NT')
-    runString = "set PORT=3002 && craco start";
+    runString = "set PORT=3002 && craco start --color";
 else
-    runString = "PORT=3002 craco start";
+    runString = "PORT=3002 craco start --color";
 
-exec(runString);
-console.log("Starter med commando: " + runString);
+var cracoStart = exec(runString);
+console.log("Starter med commando: " + runString + "\n");
+
+cracoStart.stdout.on('data', function (data) {
+    console.log(data.toString());
+});
+
+cracoStart.stderr.on('data', function (data) {
+    console.log('ERROR: ' + data.toString());
+});
+
+cracoStart.on('exit', function (code) {
+    console.log('child process exited with code ' + code.toString());
+});


### PR DESCRIPTION
Kjører opp applikasjonen på port 3002.
Lar isDev-sjekker ikke bry seg om portnummer, kun at det kjører på localhost.
Lager et eget script start.js for sette opp portnummer-environment korrekt, avhengig av om det er windows eller mac på underliggende OS.

Kan noen Mac-ere teste at `npm start` fungerer som det skal på mac? :) 