### PR TITLE
Ta i bruk nytt endepunkt for raskere utbetalings-sjekk på landingssiden

### DIFF
--- a/src/saksoversikt/SaksoversiktDineSaker.tsx
+++ b/src/saksoversikt/SaksoversiktDineSaker.tsx
@@ -11,17 +11,16 @@ import Paginering from "../components/paginering/Paginering";
 import {Sakstype} from "../redux/innsynsdata/innsynsdataReducer";
 import {parse} from "query-string";
 import {history} from "../configureStore";
-import useUtbetalingerService, {UtbetalingSakType} from "../utbetalinger/service/useUtbetalingerService";
 import {REST_STATUS} from "../utils/restUtils";
 import DineUtbetalingerPanel from "./dineUtbetalinger/DineUtbetalingerPanel";
+import useUtbetalingerExistsService from "../utbetalinger/service/useUtbetalingerExistsService";
 
 const SaksoversiktDineSaker: React.FC<{saker: Sakstype[]}> = ({saker}) => {
     const [periode, setPeriode] = useState<string>("alle");
 
-    // Denne er idag veldig tung. Serlig for test personer med maange søknader.
-    const utbetalingerService = useUtbetalingerService(12);
-    let utbetalinger: UtbetalingSakType[] =
-        utbetalingerService.restStatus === REST_STATUS.OK ? utbetalingerService.payload : [];
+    const utbetalingerExistsService = useUtbetalingerExistsService(12);
+    let utbetalingerExists: boolean =
+        utbetalingerExistsService.restStatus === REST_STATUS.OK ? utbetalingerExistsService.payload : false;
 
     let filtrerteSaker: Sakstype[];
 
@@ -140,7 +139,7 @@ const SaksoversiktDineSaker: React.FC<{saker: Sakstype[]}> = ({saker}) => {
             )}
 
             <>
-                {utbetalinger.length > 0 && <DineUtbetalingerPanel />}
+                {utbetalingerExists && <DineUtbetalingerPanel />}
 
                 <Subheader className="panel-luft-over">
                     <Undertittel>Relatert informasjon</Undertittel>

--- a/src/utbetalinger/service/useUtbetalingerExistsService.ts
+++ b/src/utbetalinger/service/useUtbetalingerExistsService.ts
@@ -1,0 +1,26 @@
+import {useEffect, useState} from "react";
+import {fetchToJson, REST_STATUS} from "../../utils/restUtils";
+import {ServiceHookTypes} from "../../utils/ServiceHookTypes";
+import {logErrorMessage} from "../../redux/innsynsdata/loggActions";
+
+const useUtbetalingerExistsService = (month: number) => {
+    const [result, setResult] = useState<ServiceHookTypes<boolean>>({
+        restStatus: REST_STATUS.PENDING,
+    });
+
+    useEffect(() => {
+        const url = "/innsyn/utbetalinger/exists";
+        setResult({restStatus: REST_STATUS.PENDING});
+        fetchToJson(url + "?month=" + month)
+            .then((response: any) => {
+                setResult({restStatus: REST_STATUS.OK, payload: response});
+            })
+            .catch((error: any) => {
+                logErrorMessage(error.message, error.navCallId);
+                setResult({restStatus: REST_STATUS.FEILET, error});
+            });
+    }, [month]);
+    return result;
+};
+
+export default useUtbetalingerExistsService;


### PR DESCRIPTION
⚠️ NB: Kan ikke bli deployet før etter https://github.com/navikt/sosialhjelp-innsyn-api/pull/207 ⚠️ 

Tar i bruk nytt endepunkt for å sjekke om en bruker har utbetalinger.
Denne sjekken er raskere fordi den returnerer true ved første resultat. Tidligere fikk denne sjekken ugyldig token i q0 fordi, den brukte mer enn 2 minutter. Nå tok den 8.9 sekunder.
Funksjonaliteten er viktigst for testing med Nathalie og for brukere som har veldig mange søknader.