### PR TITLE
Endrer hotjartrigger etter avtale med Wilhelm:

### DIFF
--- a/src/components/hotjarTrigger/HotjarTrigger.js
+++ b/src/components/hotjarTrigger/HotjarTrigger.js
@@ -22,23 +22,15 @@ HotjarTrigger.propTypes = {
 };
 
 export const SoknadMedInnsynHotjarTrigger = ({children}) => (
-    <HotjarTrigger hotjarTrigger="digisos_soknad_med_innsyn">{children}</HotjarTrigger>
+    <HotjarTrigger hotjarTrigger="digisos_innsyn">{children}</HotjarTrigger>
 );
 
 SoknadMedInnsynHotjarTrigger.propTypes = {
     children: node,
 };
 
-export const SoknadFraBergenHotjarTrigger = ({children}) => (
-    <HotjarTrigger hotjarTrigger="digisos_soknad_fra_bergen">{children}</HotjarTrigger>
-);
-
-SoknadFraBergenHotjarTrigger.propTypes = {
-    children: node,
-};
-
 export const SoknadUtenInnsynHotjarTrigger = ({children}) => (
-    <HotjarTrigger hotjarTrigger="digisos_soknad_uten_innsyn">{children}</HotjarTrigger>
+    <HotjarTrigger hotjarTrigger="digisos_ikke_innsyn">{children}</HotjarTrigger>
 );
 
 SoknadUtenInnsynHotjarTrigger.propTypes = {

--- a/src/innsyn/SaksStatus.tsx
+++ b/src/innsyn/SaksStatus.tsx
@@ -103,15 +103,17 @@ const SaksStatusView: React.FC<Props> = ({match}) => {
 
             <DriftsmeldingAlertstripe />
 
+            <ForelopigSvarAlertstripe />
+
             {shouldShowHotjarTrigger() && isKommuneMedInnsyn(kommuneResponse, innsynsdata.soknadsStatus.status) && (
                 <SoknadMedInnsynHotjarTrigger>
-                    <ForelopigSvarAlertstripe />
+                    <div />
                 </SoknadMedInnsynHotjarTrigger>
             )}
 
             {shouldShowHotjarTrigger() && isKommuneUtenInnsyn(kommuneResponse) && (
                 <SoknadUtenInnsynHotjarTrigger>
-                    <ForelopigSvarAlertstripe />
+                    <div />
                 </SoknadUtenInnsynHotjarTrigger>
             )}
 

--- a/src/innsyn/SaksStatus.tsx
+++ b/src/innsyn/SaksStatus.tsx
@@ -21,12 +21,8 @@ import Brodsmulesti, {UrlType} from "../components/brodsmuleSti/BrodsmuleSti";
 import {soknadsStatusTittel} from "../components/soknadsStatus/soknadsStatusUtils";
 import Panel from "nav-frontend-paneler";
 import {Systemtittel} from "nav-frontend-typografi";
-import {
-    SoknadFraBergenHotjarTrigger,
-    SoknadMedInnsynHotjarTrigger,
-    SoknadUtenInnsynHotjarTrigger,
-} from "../components/hotjarTrigger/HotjarTrigger";
-import {isKommuneBergen, isKommuneMedInnsynUtenBergen, isKommuneUtenInnsynUtenBergen} from "./saksStatusUtils";
+import {SoknadMedInnsynHotjarTrigger, SoknadUtenInnsynHotjarTrigger} from "../components/hotjarTrigger/HotjarTrigger";
+import {isKommuneMedInnsyn, isKommuneUtenInnsyn} from "./saksStatusUtils";
 import {AlertStripeAdvarsel} from "nav-frontend-alertstriper";
 
 interface Props {
@@ -77,6 +73,14 @@ const SaksStatusView: React.FC<Props> = ({match}) => {
     const statusTittel = soknadsStatusTittel(innsynsdata.soknadsStatus.status, intl);
     document.title = statusTittel;
 
+    const shouldShowHotjarTrigger = () => {
+        return (
+            restStatus.soknadsStatus === REST_STATUS.OK &&
+            restStatus.kommune === REST_STATUS.OK &&
+            (innsynsdata.soknadsStatus.tidspunktSendt == null || innsynsdata.soknadsStatus.soknadsalderIMinutter > 60)
+        );
+    };
+
     return (
         <>
             {!leserData(restStatus.saksStatus) && sakStatusHarFeilet && (
@@ -99,19 +103,13 @@ const SaksStatusView: React.FC<Props> = ({match}) => {
 
             <DriftsmeldingAlertstripe />
 
-            {isKommuneMedInnsynUtenBergen(kommuneResponse, restStatus.kommune) && (
+            {shouldShowHotjarTrigger() && isKommuneMedInnsyn(kommuneResponse, innsynsdata.soknadsStatus.status) && (
                 <SoknadMedInnsynHotjarTrigger>
                     <ForelopigSvarAlertstripe />
                 </SoknadMedInnsynHotjarTrigger>
             )}
 
-            {isKommuneBergen(kommuneResponse) && (
-                <SoknadFraBergenHotjarTrigger>
-                    <ForelopigSvarAlertstripe />
-                </SoknadFraBergenHotjarTrigger>
-            )}
-
-            {isKommuneUtenInnsynUtenBergen(kommuneResponse, restStatus.kommune) && (
+            {shouldShowHotjarTrigger() && isKommuneUtenInnsyn(kommuneResponse) && (
                 <SoknadUtenInnsynHotjarTrigger>
                     <ForelopigSvarAlertstripe />
                 </SoknadUtenInnsynHotjarTrigger>

--- a/src/innsyn/saksStatusUtils.test.ts
+++ b/src/innsyn/saksStatusUtils.test.ts
@@ -1,124 +1,51 @@
 import {KommuneResponse} from "../redux/innsynsdata/innsynsdataReducer";
-import {
-    isKommuneBergen,
-    isKommuneInfoFetched,
-    isKommuneMedInnsynUtenBergen,
-    isKommuneUtenInnsynUtenBergen,
-} from "./saksStatusUtils";
-import {REST_STATUS} from "../utils/restUtils";
+import {isKommuneMedInnsyn, isKommuneUtenInnsyn} from "./saksStatusUtils";
+import {SoknadsStatusEnum} from "../components/soknadsStatus/soknadsStatusUtils";
 
 describe("Hotjar-trigger utils", () => {
-    it("before fetching kommuneResponse, all hotjartriggers should be disabled", () => {
-        const initialKommuneResponse: KommuneResponse = {
-            erInnsynDeaktivert: false,
-            erInnsynMidlertidigDeaktivert: false,
-            erInnsendingEttersendelseDeaktivert: false,
-            erInnsendingEttersendelseMidlertidigDeaktivert: false,
-            tidspunkt: null,
-            kommunenummer: null,
-        };
+    const aktivertInnsynKommuneResponse: KommuneResponse = {
+        erInnsynDeaktivert: false,
+        erInnsynMidlertidigDeaktivert: false,
+        erInnsendingEttersendelseDeaktivert: false,
+        erInnsendingEttersendelseMidlertidigDeaktivert: false,
+        tidspunkt: null,
+        kommunenummer: "0001",
+    };
 
-        // INITIALISERT
-        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
-        expect(isKommuneInfoFetched(REST_STATUS.INITIALISERT)).toBe(false);
-        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.INITIALISERT)).toBe(false);
-        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.INITIALISERT)).toBe(false);
+    const deaktivertInnsynKommuneResponse: KommuneResponse = {
+        erInnsynDeaktivert: true,
+        erInnsynMidlertidigDeaktivert: false,
+        erInnsendingEttersendelseDeaktivert: false,
+        erInnsendingEttersendelseMidlertidigDeaktivert: false,
+        tidspunkt: null,
+        kommunenummer: "0001",
+    };
 
-        // PENDING
-        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
-        expect(isKommuneInfoFetched(REST_STATUS.PENDING)).toBe(false);
-        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.PENDING)).toBe(false);
-        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.PENDING)).toBe(false);
+    it("ingen kommunerespons, should not trigger any hotjar", () => {
+        expect(isKommuneUtenInnsyn(undefined)).toBe(false);
+        expect(isKommuneMedInnsyn(undefined, SoknadsStatusEnum.MOTTATT)).toBe(false);
     });
 
-    it("failing kommuneResponse should trigger hotjar utenInnsyn", () => {
-        const initialKommuneResponse: KommuneResponse = {
-            erInnsynDeaktivert: false,
-            erInnsynMidlertidigDeaktivert: false,
-            erInnsendingEttersendelseDeaktivert: false,
-            erInnsendingEttersendelseMidlertidigDeaktivert: false,
-            tidspunkt: null,
-            kommunenummer: null,
-        };
-
-        // FEILET
-        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
-        expect(isKommuneInfoFetched(REST_STATUS.FEILET)).toBe(true);
-        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.FEILET)).toBe(false);
-        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.FEILET)).toBe(true);
-
-        // UNAUTHORIZED
-        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
-        expect(isKommuneInfoFetched(REST_STATUS.UNAUTHORIZED)).toBe(true);
-        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.UNAUTHORIZED)).toBe(false);
-        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.UNAUTHORIZED)).toBe(true);
-
-        // SERVICE_UNAVAILABLE
-        expect(isKommuneBergen(initialKommuneResponse)).toBe(false);
-        expect(isKommuneInfoFetched(REST_STATUS.SERVICE_UNAVAILABLE)).toBe(true);
-        expect(isKommuneMedInnsynUtenBergen(initialKommuneResponse, REST_STATUS.SERVICE_UNAVAILABLE)).toBe(false);
-        expect(isKommuneUtenInnsynUtenBergen(initialKommuneResponse, REST_STATUS.SERVICE_UNAVAILABLE)).toBe(true);
+    it("deaktivert innsyn, should trigger hotjar utenInnsyn", () => {
+        expect(isKommuneUtenInnsyn(deaktivertInnsynKommuneResponse)).toBe(true);
     });
 
-    it("kommunenummer 4601 should trigger hotjar for Bergen", () => {
-        const kommuneResponseBergenAktivert: KommuneResponse = {
-            erInnsynDeaktivert: false,
-            erInnsynMidlertidigDeaktivert: false,
-            erInnsendingEttersendelseDeaktivert: false,
-            erInnsendingEttersendelseMidlertidigDeaktivert: false,
-            tidspunkt: null,
-            kommunenummer: "4601",
-        };
-        const kommuneResponseBergenDeaktivert: KommuneResponse = {
-            erInnsynDeaktivert: true,
-            erInnsynMidlertidigDeaktivert: false,
-            erInnsendingEttersendelseDeaktivert: false,
-            erInnsendingEttersendelseMidlertidigDeaktivert: false,
-            tidspunkt: null,
-            kommunenummer: "4601",
-        };
-        const kommuneRestStatus: REST_STATUS = REST_STATUS.OK;
-
-        expect(isKommuneBergen(kommuneResponseBergenAktivert)).toBe(true);
-        expect(isKommuneInfoFetched(kommuneRestStatus)).toBe(true);
-        expect(isKommuneMedInnsynUtenBergen(kommuneResponseBergenAktivert, kommuneRestStatus)).toBe(false);
-        expect(isKommuneUtenInnsynUtenBergen(kommuneResponseBergenAktivert, kommuneRestStatus)).toBe(false);
-
-        expect(isKommuneBergen(kommuneResponseBergenDeaktivert)).toBe(true);
-        expect(isKommuneInfoFetched(kommuneRestStatus)).toBe(true);
-        expect(isKommuneMedInnsynUtenBergen(kommuneResponseBergenDeaktivert, kommuneRestStatus)).toBe(false);
-        expect(isKommuneUtenInnsynUtenBergen(kommuneResponseBergenDeaktivert, kommuneRestStatus)).toBe(false);
+    it("deaktivert innsyn, should not trigger hotjar medInnsyn", () => {
+        expect(isKommuneMedInnsyn(deaktivertInnsynKommuneResponse, SoknadsStatusEnum.MOTTATT)).toBe(false);
     });
 
-    it("deaktivert innsyn (and not Bergen), should trigger hotjar utenInnsyn", () => {
-        const kommuneResponse: KommuneResponse = {
-            erInnsynDeaktivert: true,
-            erInnsynMidlertidigDeaktivert: false,
-            erInnsendingEttersendelseDeaktivert: false,
-            erInnsendingEttersendelseMidlertidigDeaktivert: false,
-            tidspunkt: null,
-            kommunenummer: "0001",
-        };
-
-        expect(isKommuneBergen(kommuneResponse)).toBe(false);
-        expect(isKommuneInfoFetched(REST_STATUS.OK)).toBe(true);
-        expect(isKommuneMedInnsynUtenBergen(kommuneResponse, REST_STATUS.OK)).toBe(false);
-        expect(isKommuneUtenInnsynUtenBergen(kommuneResponse, REST_STATUS.OK)).toBe(true);
+    it("aktivert innsyn, should not trigger utenInnsyn", () => {
+        expect(isKommuneUtenInnsyn(aktivertInnsynKommuneResponse)).toBe(false);
     });
 
-    it("aktivert innsyn (and not Bergen), should trigger hotjar medInnsyn", () => {
-        const kommuneResponse: KommuneResponse = {
-            erInnsynDeaktivert: false,
-            erInnsynMidlertidigDeaktivert: false,
-            erInnsendingEttersendelseDeaktivert: false,
-            erInnsendingEttersendelseMidlertidigDeaktivert: false,
-            tidspunkt: null,
-            kommunenummer: "0001",
-        };
+    it("aktivert innsyn med søknad SENDT, should not trigger medInnsyn", () => {
+        expect(isKommuneMedInnsyn(aktivertInnsynKommuneResponse, SoknadsStatusEnum.SENDT)).toBe(false);
+    });
 
-        expect(isKommuneBergen(kommuneResponse)).toBe(false);
-        expect(isKommuneInfoFetched(REST_STATUS.OK)).toBe(true);
-        expect(isKommuneMedInnsynUtenBergen(kommuneResponse, REST_STATUS.OK)).toBe(true);
-        expect(isKommuneUtenInnsynUtenBergen(kommuneResponse, REST_STATUS.OK)).toBe(false);
+    it("aktivert innsyn med søknad !SENDT, should trigger hotjar medInnsyn", () => {
+        expect(isKommuneMedInnsyn(aktivertInnsynKommuneResponse, SoknadsStatusEnum.MOTTATT)).toBe(true);
+        expect(isKommuneMedInnsyn(aktivertInnsynKommuneResponse, SoknadsStatusEnum.UNDER_BEHANDLING)).toBe(true);
+        expect(isKommuneMedInnsyn(aktivertInnsynKommuneResponse, SoknadsStatusEnum.FERDIGBEHANDLET)).toBe(true);
+        expect(isKommuneMedInnsyn(aktivertInnsynKommuneResponse, SoknadsStatusEnum.BEHANDLES_IKKE)).toBe(true);
     });
 });

--- a/src/innsyn/saksStatusUtils.ts
+++ b/src/innsyn/saksStatusUtils.ts
@@ -1,43 +1,15 @@
 import {KommuneResponse} from "../redux/innsynsdata/innsynsdataReducer";
-import {REST_STATUS} from "../utils/restUtils";
+import {SoknadsStatusEnum} from "../components/soknadsStatus/soknadsStatusUtils";
 
-const kommunenummerBergen = "4601";
-
-export function isKommuneInfoFetched(kommuneRestStatus: REST_STATUS): boolean {
-    return kommuneRestStatus !== REST_STATUS.INITIALISERT && kommuneRestStatus !== REST_STATUS.PENDING;
-}
-
-export function isKommuneInfoFeilet(kommuneRestStatus: REST_STATUS): boolean {
-    return (
-        kommuneRestStatus === REST_STATUS.FEILET ||
-        kommuneRestStatus === REST_STATUS.UNAUTHORIZED ||
-        kommuneRestStatus === REST_STATUS.SERVICE_UNAVAILABLE
-    );
-}
-
-export function isKommuneBergen(kommuneResponse: KommuneResponse | undefined): boolean {
-    return kommuneResponse != null && kommuneResponse.kommunenummer === kommunenummerBergen;
-}
-
-export function isKommuneMedInnsynUtenBergen(
-    kommuneResponse: KommuneResponse | undefined,
-    kommuneRestStatus: REST_STATUS
-): boolean {
+export function isKommuneMedInnsyn(kommuneResponse: KommuneResponse | undefined, soknadStatus: String | null): boolean {
     return (
         kommuneResponse != null &&
         !kommuneResponse.erInnsynDeaktivert &&
-        !isKommuneBergen(kommuneResponse) &&
-        kommuneRestStatus === REST_STATUS.OK
+        soknadStatus != null &&
+        soknadStatus !== SoknadsStatusEnum.SENDT
     );
 }
 
-export function isKommuneUtenInnsynUtenBergen(
-    kommuneResponse: KommuneResponse | undefined,
-    kommuneRestStatus: REST_STATUS
-): boolean {
-    return (
-        (kommuneResponse == null || kommuneResponse.erInnsynDeaktivert || isKommuneInfoFeilet(kommuneRestStatus)) &&
-        !isKommuneBergen(kommuneResponse) &&
-        isKommuneInfoFetched(kommuneRestStatus)
-    );
+export function isKommuneUtenInnsyn(kommuneResponse: KommuneResponse | undefined): boolean {
+    return kommuneResponse != null && kommuneResponse.erInnsynDeaktivert;
 }

--- a/src/innsyn/saksStatusUtils.ts
+++ b/src/innsyn/saksStatusUtils.ts
@@ -1,7 +1,7 @@
 import {KommuneResponse} from "../redux/innsynsdata/innsynsdataReducer";
 import {SoknadsStatusEnum} from "../components/soknadsStatus/soknadsStatusUtils";
 
-export function isKommuneMedInnsyn(kommuneResponse: KommuneResponse | undefined, soknadStatus: String | null): boolean {
+export function isKommuneMedInnsyn(kommuneResponse: KommuneResponse | undefined, soknadStatus: string | null): boolean {
     return (
         kommuneResponse != null &&
         !kommuneResponse.erInnsynDeaktivert &&

--- a/src/redux/innsynsdata/innsynsdataReducer.ts
+++ b/src/redux/innsynsdata/innsynsdataReducer.ts
@@ -140,6 +140,8 @@ export interface VedleggActionType {
 
 export interface Status {
     status: string | null;
+    tidspunktSendt: string | null;
+    soknadsalderIMinutter: number;
 }
 
 export interface Hendelse {
@@ -222,6 +224,8 @@ export const initialState: InnsynsdataType = {
     oppgaveVedlegsOpplastingFeilet: false,
     soknadsStatus: {
         status: null,
+        tidspunktSendt: null,
+        soknadsalderIMinutter: -1,
     },
     hendelser: [],
     vedlegg: [],


### PR DESCRIPTION
Endrer hotjartrigger etter avtale med Wilhelm:
* Ingen hotjartrigger dersom søknaden er mindre enn 1t gammel (pga gir falske positive, folk er fornøyde rett etter de har sendt inn søknaden)
* Søknader med deaktivert innsyn trigger hotjar uten innsyn
* Søknader med aktivert innsyn og med innsynsfil trigger hotjar med innsyn
* Ingen hotjartrigger dersom kommunen har aktivert innsyn, men det ikke er noen innsynsfil på søknaden. Dette fordi det er umulig for oss å vite om dette er en ny søknad som snart vil få innsyn, eller om dette er en søknad som ble sendt inn før kommunen aktiverte innsyn, og dermed aldri vil få innsynsfil.

(NB: per i dag er det ingen hotjartrigger ved papirsøknader, men det er heller ingen som sender innsyn papirsøknader enda)