### PR TITLE
Feature/gjenbruke call id ved feilet restkall logg

### DIFF
--- a/src/redux/innsynsdata/loggActions.ts
+++ b/src/redux/innsynsdata/loggActions.ts
@@ -3,7 +3,7 @@ import {fetchPost} from "../../utils/restUtils";
 const LOG_URL = "/info/logg";
 
 export function logInfoMessage(message: string, navCallId?: string) {
-    fetchPost(LOG_URL, JSON.stringify(createLogEntry(message, "INFO", navCallId)))
+    fetchPost(LOG_URL, JSON.stringify(createLogEntry(message, "INFO")), undefined, navCallId)
         .then(() => {})
         .catch(() => {
             return; // Not important to handle those errors
@@ -11,14 +11,14 @@ export function logInfoMessage(message: string, navCallId?: string) {
 }
 
 export function logErrorMessage(message: string, navCallId?: string) {
-    fetchPost(LOG_URL, JSON.stringify(createLogEntry(message, "ERROR", navCallId)))
+    fetchPost(LOG_URL, JSON.stringify(createLogEntry(message, "ERROR")), undefined, navCallId)
         .then(() => {})
         .catch(() => {
             return; // Not important to handle those errors
         });
 }
 
-function createLogEntry(message: string, level: LogLevel, navCallId?: string) {
+function createLogEntry(message: string, level: LogLevel) {
     return {
         level: level,
         message: message,
@@ -27,7 +27,6 @@ function createLogEntry(message: string, level: LogLevel, navCallId?: string) {
         columnNumber: "",
         url: window.location.href,
         userAgent: window.navigator.userAgent,
-        loggenGjelderForCallId: navCallId,
     };
 }
 

--- a/src/utils/restUtils.test.ts
+++ b/src/utils/restUtils.test.ts
@@ -16,6 +16,12 @@ describe("RestUtilsTest", () => {
 });
 
 describe("getOriginAwareHeaders", () => {
+    it("should use callId from parameters if set", () => {
+        const callId = "callId";
+        const headers = getOriginAwareHeaders("https://www.nav.no", undefined, callId);
+        expect(headers.get("Nav-Call-Id")).toBe(callId);
+    });
+
     it("should include Content-Type, when not multipart-request", () => {
         const headers = getOriginAwareHeaders("https://www.nav.no");
         expect(headers.has("Content-Type")).toBeTruthy();

--- a/src/utils/restUtils.test.ts
+++ b/src/utils/restUtils.test.ts
@@ -1,4 +1,4 @@
-import {REST_STATUS, skalViseLastestripe} from "./restUtils";
+import {getOriginAwareHeaders, REST_STATUS, skalViseLastestripe} from "./restUtils";
 
 describe("RestUtilsTest", () => {
     it("should show lastestripe for REST_STATUS.PENDING", () => {
@@ -13,4 +13,58 @@ describe("RestUtilsTest", () => {
     it("should not show lastestripe for REST_STATUS.OK", () => {
         expect(skalViseLastestripe(REST_STATUS.OK)).toBe(false);
     });
+});
+
+describe("getOriginAwareHeaders", () => {
+    it("should include Content-Type, when not multipart-request", () => {
+        const headers = getOriginAwareHeaders("https://www.nav.no");
+        expect(headers.has("Content-Type")).toBeTruthy();
+    });
+
+    it("should not include Content-Type, when multipart-request", () => {
+        const headers = getOriginAwareHeaders("https://www.nav.no", "multipart/form-data");
+        expect(headers.has("Content-Type")).toBeFalsy();
+    });
+
+    it("should include Accept and Nav-Call-Id, idependent of contentType", () => {
+        let headers = getOriginAwareHeaders("https://www.nav.no", "multipart/form-data");
+        expect(headers.has("Accept")).toBeTruthy();
+        expect(headers.has("Nav-Call-Id")).toBeTruthy();
+
+        headers = getOriginAwareHeaders("https://www.nav.no");
+        expect(headers.has("Accept")).toBeTruthy();
+        expect(headers.has("Nav-Call-Id")).toBeTruthy();
+    });
+
+    it("should not include Authorization or istio-headers in prod", () => {
+        let headers = getOriginAwareHeaders("https://www.nav.no");
+        expect(headers.has("Authorization")).toBeFalsy();
+        expect(headers.has("X-B3-TraceId")).toBeFalsy();
+        expect(headers.has("X-B3-SpanId")).toBeFalsy();
+
+        headers = getOriginAwareHeaders("https://www.nav.no", "multipart/form-data");
+        expect(headers.has("Authorization")).toBeFalsy();
+        expect(headers.has("X-B3-TraceId")).toBeFalsy();
+        expect(headers.has("X-B3-SpanId")).toBeFalsy();
+    });
+
+    it("labs and dev-gcp should contain Authorization and istio-headers", () => {
+        let headers = getOriginAwareHeaders("https://sosialhjelp-innsyn.dev.nav.no");
+        containsAllHeaders(headers);
+
+        headers = getOriginAwareHeaders("https://sosialhjelp-innsyn.labs.nais.io");
+        containsAllHeaders(headers);
+
+        headers = getOriginAwareHeaders("http://digisos.labs.nais.io/");
+        containsAllHeaders(headers);
+    });
+
+    const containsAllHeaders = (headers: Headers) => {
+        expect(headers.has("Authorization")).toBeTruthy();
+        expect(headers.has("X-B3-TraceId")).toBeTruthy();
+        expect(headers.has("X-B3-SpanId")).toBeTruthy();
+        expect(headers.has("Accept")).toBeTruthy();
+        expect(headers.has("Nav-Call-Id")).toBeTruthy();
+        expect(headers.has("Content-Type")).toBeTruthy();
+    };
 });

--- a/src/utils/restUtils.ts
+++ b/src/utils/restUtils.ts
@@ -148,14 +148,14 @@ export enum REST_STATUS {
     SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE",
 }
 
-export const getHeaders = (contentType?: string) => {
-    return getOriginAwareHeaders(window.location.origin, contentType);
+export const getHeaders = (contentType?: string, callId?: string) => {
+    return getOriginAwareHeaders(window.location.origin, contentType, callId);
 };
 
-export const getOriginAwareHeaders = (origin: string, contentType?: string): Headers => {
+export const getOriginAwareHeaders = (origin: string, contentType?: string, callId?: string): Headers => {
     let headers = new Headers({
         Accept: "application/json, text/plain, */*",
-        "Nav-Call-Id": generateCallId(),
+        "Nav-Call-Id": callId ?? generateCallId(),
     });
 
     if (!contentType || contentType !== "multipart/form-data") {
@@ -190,10 +190,11 @@ export const serverRequest = (
     urlPath: string,
     body: string | null | FormData,
     contentType?: string,
-    isSoknadApi?: boolean
+    isSoknadApi?: boolean,
+    callId?: string
 ) => {
     const OPTIONS: RequestInit = {
-        headers: getHeaders(contentType),
+        headers: getHeaders(contentType, callId),
         method: method,
         credentials: determineCredentialsParameter(),
         body: body ? body : undefined,
@@ -284,8 +285,8 @@ export function fetchPut(urlPath: string, body: string) {
     return serverRequest(RequestMethod.PUT, urlPath, body);
 }
 
-export function fetchPost(urlPath: string, body: string | FormData, contentType?: string) {
-    return serverRequest(RequestMethod.POST, urlPath, body, contentType);
+export function fetchPost(urlPath: string, body: string | FormData, contentType?: string, callId?: string) {
+    return serverRequest(RequestMethod.POST, urlPath, body, contentType, undefined, callId);
 }
 
 export function fetchPostGetErrors(urlPath: string, body: string | FormData, contentType?: string) {

--- a/src/utils/restUtils.ts
+++ b/src/utils/restUtils.ts
@@ -154,19 +154,14 @@ export const getHeaders = (contentType?: string) => {
 
 export const getOriginAwareHeaders = (origin: string, contentType?: string): Headers => {
     let headers = new Headers({
-        "Content-Type": contentType ? contentType : "application/json; charset=utf-8",
         Accept: "application/json, text/plain, */*",
         "Nav-Call-Id": generateCallId(),
     });
-    // Browser setter content type header automatisk til multipart/form-data: boundary xyz
-    if (contentType && contentType === "multipart/form-data") {
-        headers = new Headers({
-            Accept: "application/json, text/plain, */*",
-            "Nav-Call-Id": generateCallId(),
-        });
+
+    if (!contentType || contentType !== "multipart/form-data") {
+        headers.append("Content-Type", contentType ? contentType : "application/json; charset=utf-8");
     }
 
-    const origin = window.location.origin;
     if (isMockServer(origin) || (isDev(origin) && !erMedLoginApi())) {
         headers.append("Authorization", "dummytoken");
     }

--- a/src/utils/restUtils.ts
+++ b/src/utils/restUtils.ts
@@ -149,6 +149,10 @@ export enum REST_STATUS {
 }
 
 export const getHeaders = (contentType?: string) => {
+    return getOriginAwareHeaders(window.location.origin, contentType);
+};
+
+export const getOriginAwareHeaders = (origin: string, contentType?: string): Headers => {
     let headers = new Headers({
         "Content-Type": contentType ? contentType : "application/json; charset=utf-8",
         Accept: "application/json, text/plain, */*",


### PR DESCRIPTION
Flytte callid fra loggmeldings body til å bli gjenbrukt som headerens callId.
Dette gjør det lettere å søke opp alle feil som tillhører et rest-kall
(Selv om loggen er et eget restkall, er informasjonen kun viktig pga forrige restkall.)

Kan være lettere å lese en og en commit.
* Tester
* Refakturerer
* Flytte callId fra body og gjenbruker den som callId-header også på logg-meldingen.
