### PR TITLE
Fjerner unleash_url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM navikt/pus-decorator
 ENV APPLICATION_NAME=sosialhjelp-innsyn
 ENV HEADER_TYPE=WITH_MENU
 ENV FOOTER_TYPE=WITHOUT_ALPHABET
+ENV DISABLE_UNLEASH=true
 ENV CONTEXT_PATH=/sosialhjelp/innsyn/
 COPY /build /app

--- a/nais.yaml
+++ b/nais.yaml
@@ -53,5 +53,3 @@ spec:
       value: "true"
     - name: APPDYNAMICS_AGENT_ACCOUNT_NAME
       value: NON-PROD
-    - name: UNLEASH_API_URL
-      value: https://unleashproxy.nais.oera.no/api/


### PR DESCRIPTION
som ikke ser ut som ble brukt av noe annet enn dekoratøren. 
(ble lagt til da vi gikk over på nais for 2 år siden. Ble nok dratt med i en copy-paste)