### PR TITLE
Fjerner onClick metoder på lenker i brodsmulesti siden disse gir en del feilmeldinger i Sentry og brødsmulesti på sikt skal byttes ut med dekoratør

### DIFF
--- a/src/components/brodsmuleSti/BrodsmuleSti.tsx
+++ b/src/components/brodsmuleSti/BrodsmuleSti.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import "./brodsmuleSti.less";
 import NavFrontendChevron from "nav-frontend-chevron";
-import {onClickLink} from "../../utils/navigasjon";
 import useWindowSize from "../../utils/useWindowSize";
 import {getDittNavUrl} from "../../utils/restUtils";
+import Lenke from "nav-frontend-lenker";
 
 export enum UrlType {
     ABSOLUTE_URL = "ABSOLUTE_URL",
@@ -33,29 +33,6 @@ const Brodsmulesti: React.FC<Props> = ({tittel, className, foreldreside, tilbake
         tilbakeUrl = tilbake;
     }
 
-    const onClickTilbakePil = (event: any): void => {
-        if (tilbakePilUrlType) {
-            if (tilbakePilUrlType === UrlType.ABSOLUTE_URL) {
-                window.location.href = tilbakeUrl;
-            }
-            if (tilbakePilUrlType === UrlType.ABSOLUTE_PATH) {
-                onClickLink(event, tilbakeUrl);
-            }
-        }
-    };
-
-    const onClickForeldreLink = (event: any): void => {
-        if (foreldreside && foreldreside.urlType) {
-            if (foreldreside.urlType === UrlType.ABSOLUTE_PATH) {
-                onClickLink(event, foreldreside.path);
-            }
-        } else {
-            if (foreldreside && foreldreside.path) {
-                window.location.href = foreldreside.path;
-            }
-        }
-    };
-
     let foreldresideUrl = ".";
     if (foreldreside && foreldreside.path) {
         if (foreldreside.urlType === UrlType.ABSOLUTE_PATH) {
@@ -68,23 +45,18 @@ const Brodsmulesti: React.FC<Props> = ({tittel, className, foreldreside, tilbake
     let crumbs: React.ReactNode = (
         <>
             <div key="tilbake" className="typo-normal breadcrumbs__item">
-                <a href={getDittNavUrl()} title="Gå til Ditt NAV">
+                <Lenke href={getDittNavUrl()} title="Gå til Ditt NAV">
                     Ditt NAV
-                </a>
+                </Lenke>
             </div>
             {foreldreside && (
                 <>
                     <div key="chevron" aria-hidden={true}>
                         <NavFrontendChevron type="høyre" />
                     </div>
-                    <a
-                        href={foreldresideUrl}
-                        onClick={(event: any) => onClickForeldreLink(event)}
-                        title={foreldreside.tittel}
-                        className="breadcrumbs__parent"
-                    >
+                    <Lenke href={foreldresideUrl} title={foreldreside.tittel} className="breadcrumbs__parent">
                         {foreldreside.tittel}
-                    </a>
+                    </Lenke>
                 </>
             )}
 
@@ -108,13 +80,9 @@ const Brodsmulesti: React.FC<Props> = ({tittel, className, foreldreside, tilbake
                     <NavFrontendChevron type="venstre" />
                 </div>
                 <p className="typo-normal breadcrumbs__item">
-                    <a
-                        href={tilbakePilUrl}
-                        title="Gå til forrige side"
-                        onClick={(event: any) => onClickTilbakePil(event)}
-                    >
+                    <Lenke href={tilbakePilUrl} title="Gå til forrige side">
                         Tilbake
-                    </a>
+                    </Lenke>
                 </p>
             </>
         );

--- a/src/utils/navigasjon.ts
+++ b/src/utils/navigasjon.ts
@@ -1,9 +1,0 @@
-/* eslint-disable no-restricted-globals */
-
-const onClickLink = (event: any, sti: string) => {
-    // @ts-ignore
-    history.push(sti);
-    event.preventDefault();
-};
-
-export {onClickLink};


### PR DESCRIPTION
Vi får en del feilmeldinger i Sentry på at `history.push` ikke er en funksjon. 

Siden vi bør ta i bruk nav.no dekoratøren sin brødsmulesti i alle appene våre bytter jeg bare ut onClick metodene her med vanlig href foreløpig. 