### PR TITLE
Støtter env variabler fra både worflow_dispatch og repository_dispatch

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -27,13 +27,15 @@ jobs:
       - name: Sett env variabler
         run: |
           echo "DOCKER_TAG=${{ env.DOCKER_IMAGE }}:${{ steps.artifact-version.outputs.version }}" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=${{ github.event.inputs.cluster }}${{ github.event.client_payload.cluster }}" >> $GITHUB_ENV
+          echo "CONFIG_FILE=${{ github.event.inputs.config-file-name }}${{ github.event.client_payload.config-file-name }}" >> $GITHUB_ENV
       - name: Deploy til dev
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           RESOURCE: nais.yaml
-          CLUSTER: ${{ github.event.inputs.cluster }}
-          VARS: nais/dev/${{ github.event.inputs.config-file-name }}.json
+          CLUSTER: ${{ env.CLUSTER_NAME }}
+          VARS: nais/dev/${{ env.CONFIG_FILE }}.json
           REF: ${{ github.sha }}
           PRINT_PAYLOAD: true
           IMAGE: ${{ env.DOCKER_TAG }}

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -27,8 +27,16 @@ jobs:
       - name: Sett env variabler
         run: |
           echo "DOCKER_TAG=${{ env.DOCKER_IMAGE }}:${{ steps.artifact-version.outputs.version }}" >> $GITHUB_ENV
-          echo "CLUSTER_NAME=${{ github.event.inputs.cluster }}${{ github.event.client_payload.cluster }}" >> $GITHUB_ENV
-          echo "CONFIG_FILE=${{ github.event.inputs.config-file-name }}${{ github.event.client_payload.config-file-name }}" >> $GITHUB_ENV
+      - name: Sett cluster og config fra repository_dispatch
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          echo "CLUSTER_NAME=${{ github.event.client_payload.cluster }}" >> $GITHUB_ENV
+          echo "CONFIG_FILE=$${{ github.event.client_payload.config-file-name }}" >> $GITHUB_ENV
+      - name: Sett cluster og config fra workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "CLUSTER_NAME=${{ github.event.inputs.cluster }}" >> $GITHUB_ENV
+          echo "CONFIG_FILE=$${{ github.event.inputs.config-file-name }}" >> $GITHUB_ENV
       - name: Deploy til dev
         uses: nais/deploy/actions/deploy@v1
         env:


### PR DESCRIPTION
Har ikke funnet en bedre måte å støtte input fra både `workflow_dispatch` og `repository_dispatch`.

Alternativt kan vi introdusere en til workflow som kun er for `repository_dispatch` / deploy-scriptet.