### PR TITLE
Feature/digisos 1807 soknadsstatus undertittel ved innsyn deaktivert

### DIFF
--- a/src/components/soknadsStatus/SoknadsStatusUtenInnsyn.tsx
+++ b/src/components/soknadsStatus/SoknadsStatusUtenInnsyn.tsx
@@ -10,24 +10,17 @@ import {REST_STATUS, skalViseLastestripe} from "../../utils/restUtils";
 import DokumentSendt from "../ikoner/DokumentSendt";
 import DatoOgKlokkeslett from "../tidspunkt/DatoOgKlokkeslett";
 
-interface Props {
+const SoknadsStatusUtenInnsyn = (props: {
     restStatus: REST_STATUS;
     tidspunktSendt: string | null;
     navKontor: string | null;
     filUrl: UrlResponse | null;
-}
-
-const SoknadsStatusUtenInnsyn: React.FC<Props> = ({restStatus, tidspunktSendt, navKontor, filUrl}) => {
-    let formatertDato =
-        tidspunktSendt === null ? null : (
-            <DatoOgKlokkeslett bareDato={true} tidspunkt={tidspunktSendt} brukKortMaanedNavn={true} />
-        );
-
+}) => {
     return (
         <Panel className={"panel-uthevet"}>
             <div className="tittel_og_ikon">
-                {skalViseLastestripe(restStatus) && <Lastestriper linjer={1} />}
-                {restStatus !== REST_STATUS.FEILET && (
+                {skalViseLastestripe(props.restStatus) && <Lastestriper linjer={1} />}
+                {props.restStatus !== REST_STATUS.FEILET && (
                     <>
                         <Innholdstittel>Søknaden er sendt</Innholdstittel>
                         <DokumentSendt />
@@ -36,11 +29,13 @@ const SoknadsStatusUtenInnsyn: React.FC<Props> = ({restStatus, tidspunktSendt, n
             </div>
 
             <div className="status_detalj_panel_info_alert_luft_under">
-                {formatertDato && navKontor && filUrl && (
+                {props.tidspunktSendt && props.navKontor && props.filUrl && (
                     <Normaltekst>
-                        Sendt den {formatertDato} til {navKontor}{" "}
-                        <EksternLenke href={filUrl.link} target="_blank">
-                            {filUrl.linkTekst}
+                        Sendt den{" "}
+                        <DatoOgKlokkeslett bareDato={true} tidspunkt={props.tidspunktSendt} brukKortMaanedNavn={true} />
+                        til {props.navKontor}{" "}
+                        <EksternLenke href={props.filUrl.link} target="_blank">
+                            {props.filUrl.linkTekst}
                         </EksternLenke>
                     </Normaltekst>
                 )}

--- a/src/components/soknadsStatus/SoknadsStatusUtenInnsyn.tsx
+++ b/src/components/soknadsStatus/SoknadsStatusUtenInnsyn.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import Panel from "nav-frontend-paneler";
+import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import "./soknadsStatus.less";
+import {UrlResponse} from "../../redux/innsynsdata/innsynsdataReducer";
+import EksternLenke from "../eksternLenke/EksternLenke";
+import Lastestriper from "../lastestriper/Lasterstriper";
+
+import {REST_STATUS, skalViseLastestripe} from "../../utils/restUtils";
+import DokumentSendt from "../ikoner/DokumentSendt";
+import DatoOgKlokkeslett from "../tidspunkt/DatoOgKlokkeslett";
+
+interface Props {
+    restStatus: REST_STATUS;
+    tidspunktSendt: string | null;
+    navKontor: string | null;
+    filUrl: UrlResponse | null;
+}
+
+const SoknadsStatusUtenInnsyn: React.FC<Props> = ({restStatus, tidspunktSendt, navKontor, filUrl}) => {
+    return (
+        <Panel className={"panel-uthevet"}>
+            <div className="tittel_og_ikon">
+                {skalViseLastestripe(restStatus) && <Lastestriper linjer={1} />}
+                {restStatus !== REST_STATUS.FEILET && (
+                    <>
+                        <Innholdstittel>Søknaden er sendt</Innholdstittel>
+                        <DokumentSendt />
+                    </>
+                )}
+            </div>
+
+            <div className="status_detalj_panel_info_alert_luft_under">
+                {tidspunktSendt && navKontor && filUrl && (
+                    <Normaltekst>
+                        Sendt den{" "}
+                        {<DatoOgKlokkeslett bareDato={true} tidspunkt={tidspunktSendt} brukKortMaanedNavn={true} />} til{" "}
+                        {navKontor}{" "}
+                        {
+                            <EksternLenke href={filUrl.link} target="_blank">
+                                {filUrl.linkTekst}
+                            </EksternLenke>
+                        }
+                    </Normaltekst>
+                )}
+            </div>
+        </Panel>
+    );
+};
+
+export default SoknadsStatusUtenInnsyn;

--- a/src/components/soknadsStatus/SoknadsStatusUtenInnsyn.tsx
+++ b/src/components/soknadsStatus/SoknadsStatusUtenInnsyn.tsx
@@ -18,6 +18,11 @@ interface Props {
 }
 
 const SoknadsStatusUtenInnsyn: React.FC<Props> = ({restStatus, tidspunktSendt, navKontor, filUrl}) => {
+    let formatertDato =
+        tidspunktSendt === null ? null : (
+            <DatoOgKlokkeslett bareDato={true} tidspunkt={tidspunktSendt} brukKortMaanedNavn={true} />
+        );
+
     return (
         <Panel className={"panel-uthevet"}>
             <div className="tittel_og_ikon">
@@ -31,16 +36,12 @@ const SoknadsStatusUtenInnsyn: React.FC<Props> = ({restStatus, tidspunktSendt, n
             </div>
 
             <div className="status_detalj_panel_info_alert_luft_under">
-                {tidspunktSendt && navKontor && filUrl && (
+                {formatertDato && navKontor && filUrl && (
                     <Normaltekst>
-                        Sendt den{" "}
-                        {<DatoOgKlokkeslett bareDato={true} tidspunkt={tidspunktSendt} brukKortMaanedNavn={true} />} til{" "}
-                        {navKontor}{" "}
-                        {
-                            <EksternLenke href={filUrl.link} target="_blank">
-                                {filUrl.linkTekst}
-                            </EksternLenke>
-                        }
+                        Sendt den {formatertDato} til {navKontor}{" "}
+                        <EksternLenke href={filUrl.link} target="_blank">
+                            {filUrl.linkTekst}
+                        </EksternLenke>
                     </Normaltekst>
                 )}
             </div>

--- a/src/innsyn/SaksStatus.tsx
+++ b/src/innsyn/SaksStatus.tsx
@@ -25,6 +25,7 @@ import {isKommuneMedInnsyn, isKommuneUtenInnsyn} from "./saksStatusUtils";
 import {AlertStripeAdvarsel} from "nav-frontend-alertstriper";
 import NavFrontendSpinner from "nav-frontend-spinner";
 import {useBannerTittel} from "../redux/navigasjon/navigasjonUtils";
+import SoknadsStatusUtenInnsyn from "../components/soknadsStatus/SoknadsStatusUtenInnsyn";
 
 interface Props {
     match: {
@@ -132,11 +133,22 @@ const SaksStatusView: React.FC<Props> = ({match}) => {
 
                     <ForelopigSvarAlertstripe />
 
-                    <SoknadsStatus
-                        status={innsynsdata.soknadsStatus.status}
-                        sak={innsynsdata.saksStatus}
-                        restStatus={restStatus.soknadsStatus}
-                    />
+                    {!erPaInnsyn && (
+                        <SoknadsStatusUtenInnsyn
+                            restStatus={restStatus.soknadsStatus}
+                            tidspunktSendt={innsynsdata.soknadsStatus.tidspunktSendt}
+                            navKontor={innsynsdata.soknadsStatus.navKontor}
+                            filUrl={innsynsdata.soknadsStatus.filUrl}
+                        />
+                    )}
+
+                    {erPaInnsyn && (
+                        <SoknadsStatus
+                            status={innsynsdata.soknadsStatus.status}
+                            sak={innsynsdata.saksStatus}
+                            restStatus={restStatus.soknadsStatus}
+                        />
+                    )}
 
                     {(erPaInnsyn || innsynsdata.oppgaver.length > 0) && (
                         <Oppgaver oppgaver={innsynsdata.oppgaver} restStatus={restStatus.oppgaver} />

--- a/src/redux/innsynsdata/innsynsdataReducer.ts
+++ b/src/redux/innsynsdata/innsynsdataReducer.ts
@@ -144,6 +144,8 @@ export interface Status {
     status: string | null;
     tidspunktSendt: string | null;
     soknadsalderIMinutter: number;
+    navKontor: string | null;
+    filUrl: null | UrlResponse;
 }
 
 export interface Hendelse {
@@ -229,6 +231,8 @@ export const initialState: InnsynsdataType = {
         status: null,
         tidspunktSendt: null,
         soknadsalderIMinutter: -1,
+        navKontor: null,
+        filUrl: null,
     },
     hendelser: [],
     vedlegg: [],


### PR DESCRIPTION
Utvider backend-endepunkt for soknadsStatus for å kunne vise lenke til søknad når innsyn er deaktivert

![image](https://user-images.githubusercontent.com/41987225/104603848-1cdbce00-567d-11eb-9706-e94efa4949b4.png)
