### PR TITLE
Bytter ut lenker for opplasting av filer med knapper

### DIFF
--- a/src/components/oppgaver/FilView.tsx
+++ b/src/components/oppgaver/FilView.tsx
@@ -9,6 +9,8 @@ import VedleggModal from "./VedleggModal";
 import {FormattedMessage} from "react-intl";
 import {REST_STATUS} from "../../utils/restUtils";
 import {setOppgaveOpplastingFeiletVirussjekkPaBackend} from "../../redux/innsynsdata/innsynsDataActions";
+import {Flatknapp} from "nav-frontend-knapper";
+import {Element} from "nav-frontend-typografi";
 
 type ClickEvent = React.MouseEvent<HTMLAnchorElement, MouseEvent> | React.MouseEvent<HTMLButtonElement, MouseEvent>;
 
@@ -66,22 +68,12 @@ const FilView: React.FC<{
                     <span className="filstorrelse">({storrelse})</span>
                 </div>
                 <div className="fjern_lenkeboks">
-                    <Lenke
-                        href="#"
-                        id={"fil_" + fil.filnavn + "_fjern_lenke_knapp"}
-                        className="fjern_lenke lenke_uten_ramme"
-                        onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => onSlettClick(event)}
-                    >
-                        <FormattedMessage id="vedlegg.fjern" />
-                    </Lenke>
-                    <button
-                        id={"fil_" + fil.filnavn + "_fjern_symbol_knapp"}
-                        className="lenke"
-                        style={{borderStyle: "none"}}
-                        onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => onSlettClick(event)}
-                    >
+                    <Flatknapp mini onClick={(event) => onSlettClick(event)}>
+                        <Element>
+                            <FormattedMessage id="vedlegg.fjern" />
+                        </Element>
                         <TrashBin className="klikkbar_soppelboette" />
-                    </button>
+                    </Flatknapp>
                 </div>
             </div>
             {fil.status !== REST_STATUS.INITIALISERT &&

--- a/src/components/oppgaver/OppgaveView.tsx
+++ b/src/components/oppgaver/OppgaveView.tsx
@@ -1,6 +1,5 @@
 import React, {useState} from "react";
 import {Element, Normaltekst} from "nav-frontend-typografi";
-import Lenke from "nav-frontend-lenker";
 import UploadFileIcon from "../ikoner/UploadFile";
 import {
     Fil,
@@ -41,7 +40,7 @@ import {
     opprettFormDataMedVedleggFraOppgaver,
     maxMengdeStorrelse,
 } from "../../utils/vedleggUtils";
-import {Hovedknapp} from "nav-frontend-knapper";
+import {Flatknapp, Hovedknapp} from "nav-frontend-knapper";
 import {fetchPost, fetchPostGetErrors, REST_STATUS} from "../../utils/restUtils";
 import {logWarningMessage, logInfoMessage} from "../../redux/innsynsdata/loggActions";
 
@@ -316,10 +315,7 @@ const VelgFil = (props: {
     );
     const kanLasteOppVedlegg: boolean = erOpplastingAvVedleggTillat(kommuneResponse);
 
-    const onLinkClicked = (
-        oppgaveElementIndex: number,
-        event?: React.MouseEvent<HTMLAnchorElement, MouseEvent>
-    ): void => {
+    const onClick = (oppgaveElementIndex: number, event?: any): void => {
         const handleOnLinkClicked = (response: boolean) => {
             dispatch(setOppgaveVedleggopplastingFeilet(response));
         };
@@ -404,24 +400,18 @@ const VelgFil = (props: {
             )}
             {kanLasteOppVedlegg && (
                 <div className="oppgaver_last_opp_fil">
-                    <UploadFileIcon
-                        className="last_opp_fil_ikon"
-                        onClick={(event: any) => {
-                            onLinkClicked(props.oppgaveElementIndex, event);
-                        }}
-                    />
-                    <Lenke
-                        href="#"
+                    <Flatknapp
+                        mini
                         id={"oppgave_" + props.oppgaveElementIndex + "_last_opp_fil_knapp"}
-                        className="lenke_uten_ramme"
-                        onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-                            onLinkClicked(props.oppgaveElementIndex, event);
+                        onClick={(event) => {
+                            onClick(props.oppgaveElementIndex, event);
                         }}
                     >
+                        <UploadFileIcon className="last_opp_fil_ikon" />
                         <Element>
                             <FormattedMessage id="vedlegg.velg_fil" />
                         </Element>
-                    </Lenke>
+                    </Flatknapp>
                     <input
                         type="file"
                         id={"file_" + props.oppgaveIndex + "_" + props.oppgaveElementIndex}

--- a/src/components/oppgaver/oppgaver.less
+++ b/src/components/oppgaver/oppgaver.less
@@ -115,10 +115,6 @@
         padding: 0.5rem;
     }
 
-    .oppgaver_last_opp_fil {
-        margin-bottom: 2rem;
-    }
-
     .oppgaver_panel {
         padding: 1rem;
 
@@ -136,7 +132,7 @@
     .oppgaver_last_opp_fil {
         position: absolute;
         right: 1rem;
-        top: 0.7rem;
+        top: 0.3rem;
     }
 }
 
@@ -196,10 +192,14 @@
         .fjern_lenke {
             margin-right: 0;
         }
+
+        .klikkbar_soppelboette {
+            display: none;
+        }
     }
 
     .klikkbar_soppelboette {
-        margin-bottom: -4px;
+        margin-left: 0.25rem;
         height: 20px;
 
         path {

--- a/src/components/vedlegg/EttersendelseView.tsx
+++ b/src/components/vedlegg/EttersendelseView.tsx
@@ -9,9 +9,8 @@ import {
 } from "../../redux/innsynsdata/innsynsdataReducer";
 import FilView from "../oppgaver/FilView";
 import UploadFileIcon from "../ikoner/UploadFile";
-import Lenke from "nav-frontend-lenker";
 import {FormattedMessage} from "react-intl";
-import {Hovedknapp} from "nav-frontend-knapper";
+import {Flatknapp, Hovedknapp} from "nav-frontend-knapper";
 import {useDispatch, useSelector} from "react-redux";
 import {InnsynAppState} from "../../redux/reduxTypes";
 import {
@@ -221,6 +220,31 @@ const EttersendelseView: React.FC<Props> = ({restStatus}) => {
                             <FormattedMessage id="andre_vedlegg.tilleggsinfo" />
                         </Normaltekst>
 
+                        {kanLasteOppVedlegg && (
+                            <div className="oppgaver_last_opp_fil">
+                                <Flatknapp
+                                    mini
+                                    onClick={(event: any) => {
+                                        onLinkClicked(event);
+                                    }}
+                                >
+                                    <UploadFileIcon className="last_opp_fil_ikon" />
+                                    <Element>
+                                        <FormattedMessage id="vedlegg.velg_fil" />
+                                    </Element>
+                                </Flatknapp>
+                                <input
+                                    type="file"
+                                    id={"file_andre"}
+                                    multiple={true}
+                                    onChange={(event: ChangeEvent) => {
+                                        onChange(event);
+                                    }}
+                                    style={{display: "none"}}
+                                />
+                            </div>
+                        )}
+
                         {filer &&
                             filer.length > 0 &&
                             filer.map((fil: Fil, vedleggIndex: number) => (
@@ -235,36 +259,6 @@ const EttersendelseView: React.FC<Props> = ({restStatus}) => {
                                 />
                             ))}
 
-                        {kanLasteOppVedlegg && (
-                            <div className="oppgaver_last_opp_fil">
-                                <UploadFileIcon
-                                    className="last_opp_fil_ikon"
-                                    onClick={(event: any) => {
-                                        onLinkClicked(event);
-                                    }}
-                                />
-                                <Lenke
-                                    href="#"
-                                    className="lenke_uten_ramme"
-                                    onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-                                        onLinkClicked(event);
-                                    }}
-                                >
-                                    <Element>
-                                        <FormattedMessage id="vedlegg.velg_fil" />
-                                    </Element>
-                                </Lenke>
-                                <input
-                                    type="file"
-                                    id={"file_andre"}
-                                    multiple={true}
-                                    onChange={(event: ChangeEvent) => {
-                                        onChange(event);
-                                    }}
-                                    style={{display: "none"}}
-                                />
-                            </div>
-                        )}
                         {validerFilArrayForFeil(listeMedFilerSomFeiler) && skrivFeilmelding(listeMedFilerSomFeiler, 0)}
                     </div>
 


### PR DESCRIPTION
Litt mer semantisk riktig å bruke knapper på elementer med `onClick` etc. Har også endret rekkefølgen på rendring av knapp og filer i `EttersendelseView` slik at tab-order blir riktig.