### PR TITLE
Legger på beforeunload handler dersom vedlegg er valgt men ikke lastet opp

### DIFF
--- a/src/components/oppgaver/OppgaveView.tsx
+++ b/src/components/oppgaver/OppgaveView.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {Element, Normaltekst} from "nav-frontend-typografi";
 import UploadFileIcon from "../ikoner/UploadFile";
 import {
@@ -256,6 +256,20 @@ const OppgaveElementView = (props: {
     const oppgaveVedlegsOpplastingFeilet: boolean = useSelector(
         (state: InnsynAppState) => state.innsynsdata.oppgaveVedlegsOpplastingFeilet
     );
+
+    useEffect(() => {
+        if (props.oppgaveElement.filer && props.oppgaveElement.filer.length > 0) {
+            window.addEventListener("beforeunload", alertUser);
+        }
+        return function unload() {
+            window.removeEventListener("beforeunload", alertUser);
+        };
+    }, [props.oppgaveElement.filer]);
+
+    const alertUser = (event: any) => {
+        event.preventDefault();
+        event.returnValue = "";
+    };
 
     const visOppgaverDetaljeFeil: boolean = oppgaveVedlegsOpplastingFeilet || listeMedFilerSomFeiler.length > 0;
     return (

--- a/src/components/vedlegg/EttersendelseView.tsx
+++ b/src/components/vedlegg/EttersendelseView.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, useState} from "react";
+import React, {ChangeEvent, useEffect, useState} from "react";
 import {Element, Normaltekst} from "nav-frontend-typografi";
 import {
     Fil,
@@ -70,6 +70,21 @@ const EttersendelseView: React.FC<Props> = ({restStatus}) => {
     const listeOverOppgaveIderSomFeiletIVirussjekkPaBackend: string[] = useSelector(
         (state: InnsynAppState) => state.innsynsdata.listeOverOppgaveIderSomFeiletIVirussjekkPaBackend
     );
+
+    useEffect(() => {
+        if (filer.length > 0) {
+            window.addEventListener("beforeunload", alertUser);
+        }
+        return function unload() {
+            window.removeEventListener("beforeunload", alertUser);
+        };
+    }, [filer]);
+
+    const alertUser = (event: any) => {
+        event.preventDefault();
+        event.returnValue = "";
+    };
+
     const opplastingFeilet = harFilermedFeil(filer);
 
     const onLinkClicked = (event?: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {


### PR DESCRIPTION
Samme som for ettersendelse i søknaden. Legger på beforeunload handler slik at bruker kan få et varsel dersom de har valgt filer men ikke trykket på "Send" knapp.