### PR TITLE
Feature/utvide vedlegg json

### DIFF
--- a/src/redux/innsynsdata/innsynsdataReducer.ts
+++ b/src/redux/innsynsdata/innsynsdataReducer.ts
@@ -1,6 +1,7 @@
 import {Reducer} from "redux";
 import {setPath} from "../../utils/setPath";
 import {REST_STATUS} from "../../utils/restUtils";
+import {HendelseTypeEnum} from "../../utils/vedleggUtils";
 
 export enum SaksStatus {
     UNDER_BEHANDLING = "UNDER_BEHANDLING",
@@ -74,6 +75,8 @@ export interface OppgaveElement {
     dokumenttype: string;
     tilleggsinformasjon?: string;
     erFraInnsyn: boolean;
+    hendelsetype: HendelseTypeEnum | undefined;
+    hendelsereferanse: string | undefined;
     filer?: Fil[];
 }
 

--- a/src/utils/vedleggUtils.test.ts
+++ b/src/utils/vedleggUtils.test.ts
@@ -1,9 +1,10 @@
 import {Fil, Oppgave, OppgaveElement} from "../redux/innsynsdata/innsynsdataReducer";
 import {
+    containsUlovligeTegn,
+    HendelseTypeEnum,
+    hentFileExtension,
     opprettFormDataMedVedleggFraFiler,
     opprettFormDataMedVedleggFraOppgaver,
-    containsUlovligeTegn,
-    hentFileExtension,
 } from "./vedleggUtils";
 
 const pngFile = {filnavn: "test0.png", file: new Blob()} as Fil;
@@ -17,12 +18,15 @@ const oppgave = {
         {
             dokumenttype: "dokumenttype1",
             tilleggsinformasjon: "tilleggsinformasjon1",
+            hendelsetype: HendelseTypeEnum.DOKUMENTASJON_ETTERSPURT,
             erFraInnsyn: true,
             filer: [pngFile, jpgFile],
         } as OppgaveElement,
         {
             dokumenttype: "dokumenttype2",
             tilleggsinformasjon: "tilleggsinformasjon2",
+            hendelsetype: HendelseTypeEnum.DOKUMENTASJONKRAV,
+            hendelsereferanse: "dokkravref-1234",
             erFraInnsyn: true,
             filer: [pdfFile],
         } as OppgaveElement,
@@ -40,12 +44,15 @@ const expectedOppgaverMetadata = JSON.stringify(
             type: oppgave.oppgaveElementer[0].dokumenttype,
             tilleggsinfo: oppgave.oppgaveElementer[0].tilleggsinformasjon,
             innsendelsesfrist: oppgave.innsendelsesfrist,
+            hendelsetype: "dokumentasjonEtterspurt",
             filer: [{filnavn: pngFile.filnavn}, {filnavn: jpgFile.filnavn}],
         },
         {
             type: oppgave.oppgaveElementer[1].dokumenttype,
             tilleggsinfo: oppgave.oppgaveElementer[1].tilleggsinformasjon,
             innsendelsesfrist: oppgave.innsendelsesfrist,
+            hendelsetype: "dokumentasjonkrav",
+            hendelsereferanse: oppgave.oppgaveElementer[1].hendelsereferanse,
             filer: [{filnavn: pdfFile.filnavn}],
         },
         {
@@ -64,6 +71,7 @@ const expectedEttersendelseMetadata = JSON.stringify(
         {
             type: "annet",
             tilleggsinfo: "annet",
+            hendelsetype: "bruker",
             filer: [{filnavn: pngFile.filnavn}, {filnavn: jpgFile.filnavn}, {filnavn: pdfFile.filnavn}],
         },
     ],

--- a/src/utils/vedleggUtils.ts
+++ b/src/utils/vedleggUtils.ts
@@ -4,11 +4,20 @@ import {logWarningMessage, logInfoMessage} from "../redux/innsynsdata/loggAction
 export const maxMengdeStorrelse = 150 * 1024 * 1024;
 export const maxFilStorrelse = 10 * 1024 * 1024;
 
+export enum HendelseTypeEnum {
+    BRUKER = "bruker",
+    SOKNAD = "soknad",
+    DOKUMENTASJON_ETTERSPURT = "dokumentasjonEtterspurt",
+    DOKUMENTASJONKRAV = "dokumentasjonkrav",
+}
+
 interface Metadata {
     type: string;
     tilleggsinfo: string | undefined;
     filer: Fil[]; // Beholder kun filnavn-feltet ved serialisering
     innsendelsesfrist: string | undefined;
+    hendelsetype: HendelseTypeEnum | undefined;
+    hendelsereferanse: string | undefined;
 }
 
 export function opprettFormDataMedVedleggFraOppgaver(oppgave: Oppgave) {
@@ -19,6 +28,8 @@ export function opprettFormDataMedVedleggFraOppgaver(oppgave: Oppgave) {
             tilleggsinfo: oppgaveElement.tilleggsinformasjon,
             innsendelsesfrist: oppgave.innsendelsesfrist,
             filer: oppgaveElement.filer ? oppgaveElement.filer : [],
+            hendelsetype: oppgaveElement.hendelsetype,
+            hendelsereferanse: oppgaveElement.hendelsereferanse,
         });
     });
     return opprettFormDataMedVedlegg(metadata);
@@ -31,6 +42,8 @@ export function opprettFormDataMedVedleggFraFiler(filer: Fil[]): FormData {
             tilleggsinfo: "annet",
             filer: filer,
             innsendelsesfrist: undefined,
+            hendelsetype: HendelseTypeEnum.BRUKER,
+            hendelsereferanse: undefined,
         },
     ];
     return opprettFormDataMedVedlegg(metadata);

--- a/src/utils/vedleggUtils.ts
+++ b/src/utils/vedleggUtils.ts
@@ -52,7 +52,11 @@ export function opprettFormDataMedVedleggFraFiler(filer: Fil[]): FormData {
 function opprettFormDataMedVedlegg(metadata: Metadata[]): FormData {
     let formData = new FormData();
     // Metadata skal ikke inneholde file-blob fra Fil-typen
-    const metadataJson = JSON.stringify(metadata, ["type", "tilleggsinfo", "innsendelsesfrist", "filer", "filnavn"], 8);
+    const metadataJson = JSON.stringify(
+        metadata,
+        ["type", "tilleggsinfo", "innsendelsesfrist", "hendelsetype", "hendelsereferanse", "filer", "filnavn"],
+        8
+    );
     const metadataBlob = new Blob([metadataJson], {type: "application/json"});
     formData.append("files", metadataBlob, "metadata.json");
     metadata.forEach((filgruppe: Metadata) => {


### PR DESCRIPTION
For at backend skal vite hvilken hendelse som trigget opplastingsboksen der bruker lastet opp filene må disse sendes til frontend og frontend må sende det tilbake med filene. 

Testet at dette fungerer OK med dagens backend ✔️ 