### PR TITLE
Bytter ut nav-frontend-typografi med Typografi-elementer fra ds-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,6 @@
         "nav-frontend-lesmerpanel-style": "^2.0.1",
         "nav-frontend-paneler": "^3.0.1",
         "nav-frontend-paneler-style": "^2.0.1",
-        "nav-frontend-typografi": "^4.0.1",
-        "nav-frontend-typografi-style": "^2.0.1",
         "node-cache": "^5.1.2",
         "node-fetch": "^2.6.2",
         "prop-types": "^15.7.2",
@@ -16026,6 +16024,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nav-frontend-typografi/-/nav-frontend-typografi-4.0.1.tgz",
       "integrity": "sha512-zJrvysIWqZm0HSJqqgc1G5Lqr8bLO16B9Pg/FW7+mJQGGz/iqPhX5vvIFTXqAlXVo95qImoZ72uiWiHHRdGhPQ==",
+      "peer": true,
       "peerDependencies": {
         "classnames": "^2.2.5",
         "nav-frontend-core": "^6.0.0",
@@ -16038,6 +16037,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nav-frontend-typografi-style/-/nav-frontend-typografi-style-2.0.1.tgz",
       "integrity": "sha512-9vb94WbB4+w30ZNg3/AqgK/fsduU5eqlkY5kXTPGcRcvHpf9l8/nfQI3aD0xSETw8q8zVOwHT00XPc4jkPK9WA==",
+      "peer": true,
       "dependencies": {
         "nav-frontend-core": "^6.0.1"
       }
@@ -36443,12 +36443,14 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nav-frontend-typografi/-/nav-frontend-typografi-4.0.1.tgz",
       "integrity": "sha512-zJrvysIWqZm0HSJqqgc1G5Lqr8bLO16B9Pg/FW7+mJQGGz/iqPhX5vvIFTXqAlXVo95qImoZ72uiWiHHRdGhPQ==",
+      "peer": true,
       "requires": {}
     },
     "nav-frontend-typografi-style": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nav-frontend-typografi-style/-/nav-frontend-typografi-style-2.0.1.tgz",
       "integrity": "sha512-9vb94WbB4+w30ZNg3/AqgK/fsduU5eqlkY5kXTPGcRcvHpf9l8/nfQI3aD0xSETw8q8zVOwHT00XPc4jkPK9WA==",
+      "peer": true,
       "requires": {
         "nav-frontend-core": "^6.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "nav-frontend-lesmerpanel-style": "^2.0.1",
     "nav-frontend-paneler": "^3.0.1",
     "nav-frontend-paneler-style": "^2.0.1",
-    "nav-frontend-typografi": "^4.0.1",
-    "nav-frontend-typografi-style": "^2.0.1",
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.2",
     "prop-types": "^15.7.2",

--- a/src/App.less
+++ b/src/App.less
@@ -54,8 +54,4 @@ a.lenke:not(.knapp) {
         padding-right: 1rem;
         padding-bottom: 1rem;
     }
-
-    .typo-undertittel {
-        margin-top: 2rem;
-    }
 }

--- a/src/components/Tilgangskontrollside/Tilgangskontrollside.tsx
+++ b/src/components/Tilgangskontrollside/Tilgangskontrollside.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {useEffect, useState} from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
 import "./Tilgangskontrollside.less";
 import {useDispatch, useSelector} from "react-redux";
 import Panel from "nav-frontend-paneler";
@@ -12,6 +11,7 @@ import {skalViseFeilside} from "../../redux/innsynsdata/innsynsdataReducer";
 import {logInfoMessage, logWarningMessage} from "../../redux/innsynsdata/loggActions";
 import BigBanner from "../banner/BigBanner";
 import {ApplicationSpinner} from "../applicationSpinner/ApplicationSpinner";
+import {BodyShort, Heading} from "@navikt/ds-react";
 
 export interface TilgangskontrollsideProps {
     children: React.ReactNode;
@@ -70,11 +70,13 @@ const Tilgangskontrollside: React.FC<TilgangskontrollsideProps> = ({children}) =
                                 <div className="ellablunk-rad">
                                     <EllaBlunk size={"175"} />
                                 </div>
-                                <Innholdstittel className="blokk-xs">Hei {fornavn}</Innholdstittel>
-                                <Normaltekst>
+                                <Heading level="1" size="xlarge" spacing className="blokk-xs">
+                                    Hei {fornavn}
+                                </Heading>
+                                <BodyShort spacing>
                                     Du kan dessverre ikke bruke den digitale søknaden om økonomisk sosialhjelp. Ta
                                     kontakt med ditt lokale NAV-kontor for å få hjelp til å søke.
-                                </Normaltekst>
+                                </BodyShort>
                             </Panel>
                         </div>
                     </div>

--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -1,3 +1,4 @@
+import {Heading} from "@navikt/ds-react";
 import * as React from "react";
 import "./banner.less";
 
@@ -5,7 +6,9 @@ const Banner: React.FC<{children: React.ReactNode} & {}> = ({children}) => {
     return (
         <div className="banner">
             <div className="blokk-center">
-                <h1 className="banner__tittel">{children}</h1>
+                <Heading level="1" size="medium">
+                    {children}
+                </Heading>
             </div>
         </div>
     );

--- a/src/components/banner/BigBanner.tsx
+++ b/src/components/banner/BigBanner.tsx
@@ -3,6 +3,7 @@ import "./bigbanner.less";
 import Head from "../ikoner/Head";
 import Brodsmulesti, {UrlType} from "../brodsmuleSti/BrodsmuleSti";
 import {getDittNavUrl} from "../../utils/restUtils";
+import {Heading} from "@navikt/ds-react";
 
 const BigBanner: React.FC<{tittel: string} & {}> = ({tittel}) => {
     return (
@@ -20,7 +21,9 @@ const BigBanner: React.FC<{tittel: string} & {}> = ({tittel}) => {
                         />
                     </div>
                 </div>
-                <h1 className="big_banner__tittel">{tittel}</h1>
+                <Heading level="1" size="xlarge">
+                    {tittel}
+                </Heading>
             </div>
         </div>
     );

--- a/src/components/banner/banner.less
+++ b/src/components/banner/banner.less
@@ -8,10 +8,4 @@
     display: flex;
     align-items: center;
     border-bottom: 4px solid @navGronnLighten60;
-
-    &__tittel {
-        font-size: 16px;
-        font-weight: bold;
-        text-align: center;
-    }
 }

--- a/src/components/banner/bigbanner.less
+++ b/src/components/banner/bigbanner.less
@@ -18,20 +18,8 @@
         }
     }
 
-    &__tittel {
-        margin: 0 0;
-        font-weight: bold;
-        text-align: left;
-    }
-
-    @media screen and (min-width: 371px) {
-        &__tittel {
-            font-size: 32px;
-        }
-    }
-
     @media screen and (max-width: 370px) {
-        &__tittel {
+        h1 {
             font-size: 26px;
         }
     }

--- a/src/components/brodsmuleSti/BrodsmuleSti.tsx
+++ b/src/components/brodsmuleSti/BrodsmuleSti.tsx
@@ -3,7 +3,7 @@ import "./brodsmuleSti.less";
 import {Back, Next} from "@navikt/ds-icons";
 import useWindowSize from "../../utils/useWindowSize";
 import {getDittNavUrl} from "../../utils/restUtils";
-import {Link} from "@navikt/ds-react";
+import {BodyShort, Link} from "@navikt/ds-react";
 
 export enum UrlType {
     ABSOLUTE_URL = "ABSOLUTE_URL",
@@ -44,7 +44,7 @@ const Brodsmulesti: React.FC<Props> = ({tittel, className, foreldreside, tilbake
 
     let crumbs: React.ReactNode = (
         <>
-            <div key="tilbake" className="typo-normal breadcrumbs__item">
+            <div key="tilbake" className="breadcrumbs__item">
                 <Link href={getDittNavUrl()} title="Gå til Ditt NAV">
                     Ditt NAV
                 </Link>
@@ -63,9 +63,9 @@ const Brodsmulesti: React.FC<Props> = ({tittel, className, foreldreside, tilbake
             <div key="chevron" aria-hidden={true}>
                 <Next />
             </div>
-            <div aria-current="page" key="currentPage" className="typo-normal breadcrumbs__item breadcrumbs__current">
+            <BodyShort aria-current="page" key="currentPage" className="breadcrumbs__item breadcrumbs__current">
                 {tittel}
-            </div>
+            </BodyShort>
         </>
     );
 
@@ -79,11 +79,11 @@ const Brodsmulesti: React.FC<Props> = ({tittel, className, foreldreside, tilbake
                 <div key="chevron" aria-hidden={true}>
                     <Back />
                 </div>
-                <p className="typo-normal breadcrumbs__item">
+                <div className="breadcrumbs__item">
                     <Link href={tilbakePilUrl} title="Gå til forrige side">
                         Tilbake
                     </Link>
-                </p>
+                </div>
             </>
         );
     }

--- a/src/components/driftsmelding/Driftsmelding.tsx
+++ b/src/components/driftsmelding/Driftsmelding.tsx
@@ -5,8 +5,7 @@ import {KommuneResponse} from "../../redux/innsynsdata/innsynsdataReducer";
 import {FormattedMessage} from "react-intl";
 import {Driftsmelding, DriftsmeldingTypeKeys, getDriftsmeldingByKommuneResponse} from "./DriftsmeldingUtilities";
 import DatoOgKlokkeslett from "../tidspunkt/DatoOgKlokkeslett";
-import Element from "nav-frontend-typografi/lib/element";
-import {Alert} from "@navikt/ds-react";
+import {Alert, Label} from "@navikt/ds-react";
 import styled from "styled-components";
 
 const StyledAlert = styled(Alert)`
@@ -20,14 +19,14 @@ const DriftsmeldingAlertstripe: React.FC<{}> = () => {
 
     const driftsmelding: Driftsmelding = getDriftsmeldingByKommuneResponse(kommuneResponse);
     const tidspunkt = (
-        <Element>
+        <Label>
             <DatoOgKlokkeslett
                 bareDato={false}
                 tidspunkt={
                     kommuneResponse ? (kommuneResponse.tidspunkt ? kommuneResponse.tidspunkt.toString() : "") : ""
                 }
             />
-        </Element>
+        </Label>
     );
     switch (driftsmelding.type) {
         case DriftsmeldingTypeKeys.DRIFTSMELDING_ETTERSENDELSE_DEAKTIVERT: {

--- a/src/components/driftsmelding/DriftsmeldingVedlegg.less
+++ b/src/components/driftsmelding/DriftsmeldingVedlegg.less
@@ -9,8 +9,3 @@
     margin-right: 8px;
     height: 24px;
 }
-
-.driftsmelding-vedlegg-text-wrapper {
-    font-weight: 600;
-    font-family: "Source Sans Pro", serif;
-}

--- a/src/components/driftsmelding/DriftsmeldingVedlegg.tsx
+++ b/src/components/driftsmelding/DriftsmeldingVedlegg.tsx
@@ -6,7 +6,7 @@ import {KommuneResponse} from "../../redux/innsynsdata/innsynsdataReducer";
 import {useSelector} from "react-redux";
 import {InnsynAppState} from "../../redux/reduxTypes";
 import {isFileUploadAllowed} from "./DriftsmeldingUtilities";
-import {Normaltekst} from "nav-frontend-typografi";
+import {Label} from "@navikt/ds-react";
 
 interface Props {
     leserData: undefined | boolean;
@@ -24,9 +24,9 @@ const DriftsmeldingVedlegg: React.FC<Props> = (props: Props) => {
                 <div className={"driftsmelding-vedlegg-symbol-wrapper"}>
                     <RemoveCircle />
                 </div>
-                <Normaltekst className={"driftsmelding-vedlegg-text-wrapper"}>
+                <Label>
                     <FormattedMessage id={"driftsmelding.kanIkkeSendeVedlegg"} />
-                </Normaltekst>
+                </Label>
             </div>
         );
     }

--- a/src/components/historikk/Historikk.tsx
+++ b/src/components/historikk/Historikk.tsx
@@ -1,5 +1,4 @@
 import React, {useState} from "react";
-import {Normaltekst, Element} from "nav-frontend-typografi";
 import "./historikk.less";
 import {Hendelse} from "../../redux/innsynsdata/innsynsdataReducer";
 import EksternLenke from "../eksternLenke/EksternLenke";
@@ -9,6 +8,7 @@ import Lastestriper from "../lastestriper/Lasterstriper";
 import {REST_STATUS, skalViseLastestripe} from "../../utils/restUtils";
 import {logButtonOrLinkClick} from "../../utils/amplitude";
 import {useIntl} from "react-intl";
+import {BodyShort, Label} from "@navikt/ds-react";
 
 const MAX_ANTALL_KORT_LISTE = 3;
 
@@ -56,10 +56,10 @@ const HistorikkListe: React.FC<HistorikkListeProps> = ({hendelser, className, le
             {hendelser.map((hendelse: Hendelse, index: number) => {
                 return (
                     <li key={index}>
-                        <Element>
+                        <Label>
                             <DatoOgKlokkeslett tidspunkt={hendelse.tidspunkt} />
-                        </Element>
-                        <Normaltekst>{hendelse.beskrivelse}</Normaltekst>
+                        </Label>
+                        <BodyShort>{hendelse.beskrivelse}</BodyShort>
                         {hendelse.filUrl && (
                             <EksternLenke
                                 href={hendelse.filUrl.link}

--- a/src/components/oppgaver/AddFileButton.tsx
+++ b/src/components/oppgaver/AddFileButton.tsx
@@ -1,8 +1,7 @@
 import React, {ChangeEvent} from "react";
 import UploadFileIcon from "../ikoner/UploadFile";
-import {Element} from "nav-frontend-typografi";
 import {FormattedMessage} from "react-intl";
-import {Button} from "@navikt/ds-react";
+import {Button, Label} from "@navikt/ds-react";
 
 const AddFileButton: React.FC<{
     onChange: (event: any, dokumentasjonkravReferanse: string) => void;
@@ -28,9 +27,9 @@ const AddFileButton: React.FC<{
                 }}
             >
                 <UploadFileIcon className="last_opp_fil_ikon" />
-                <Element>
+                <Label>
                     <FormattedMessage id="vedlegg.velg_fil" />
-                </Element>
+                </Label>
             </Button>
             <input
                 type="file"

--- a/src/components/oppgaver/DokumentasjonEtterspurtElementView.tsx
+++ b/src/components/oppgaver/DokumentasjonEtterspurtElementView.tsx
@@ -13,7 +13,7 @@ import FileItemView from "./FileItemView";
 import AddFileButton from "./AddFileButton";
 import {v4 as uuidv4} from "uuid";
 import {logInfoMessage} from "../../redux/innsynsdata/loggActions";
-import {Element, Normaltekst} from "nav-frontend-typografi";
+import {BodyShort, Label} from "@navikt/ds-react";
 
 const DokumentasjonEtterspurtElementView: React.FC<{
     tittel: string;
@@ -90,11 +90,11 @@ const DokumentasjonEtterspurtElementView: React.FC<{
     return (
         <div className={"oppgaver_detalj" + (visOppgaverDetaljeFeil ? " oppgaver_detalj_feil" : "")}>
             <div className={"tekst-wrapping"}>
-                <Element>{tittel}</Element>
+                <Label>{tittel}</Label>
             </div>
             {beskrivelse && (
                 <div className={"tekst-wrapping"}>
-                    <Normaltekst className="luft_over_4px">{beskrivelse}</Normaltekst>
+                    <BodyShort>{beskrivelse}</BodyShort>
                 </div>
             )}
             <AddFileButton onChange={onChange} referanse={oppgaveId} id={uuid} />

--- a/src/components/oppgaver/DokumentasjonEtterspurtView.tsx
+++ b/src/components/oppgaver/DokumentasjonEtterspurtView.tsx
@@ -1,5 +1,4 @@
 import React, {useState} from "react";
-import {Normaltekst} from "nav-frontend-typografi";
 import {
     DokumentasjonEtterspurt,
     DokumentasjonEtterspurtElement,
@@ -32,7 +31,7 @@ import {
 } from "../../redux/innsynsdata/innsynsDataActions";
 import {logInfoMessage, logWarningMessage} from "../../redux/innsynsdata/loggActions";
 import {fileUploadFailedEvent, logButtonOrLinkClick} from "../../utils/amplitude";
-import {Button, Loader} from "@navikt/ds-react";
+import {BodyShort, Button, Loader} from "@navikt/ds-react";
 import {ErrorMessage} from "../errors/ErrorMessage";
 
 interface Props {
@@ -191,20 +190,20 @@ const DokumentasjonEtterspurtView: React.FC<Props> = ({dokumentasjonEtterspurt, 
                 }
             >
                 {oppgaverErFraInnsyn && antallDagerSidenFristBlePassert <= 0 && (
-                    <Normaltekst className="luft_under_8px">
+                    <BodyShort spacing>
                         <FormattedMessage
                             id="oppgaver.innsendelsesfrist"
                             values={{innsendelsesfrist: formatDato(dokumentasjonEtterspurt.innsendelsesfrist!)}}
                         />
-                    </Normaltekst>
+                    </BodyShort>
                 )}
                 {oppgaverErFraInnsyn && antallDagerSidenFristBlePassert > 0 && (
-                    <Normaltekst className="luft_under_8px">
+                    <BodyShort spacing>
                         <FormattedMessage
                             id="oppgaver.innsendelsesfrist_passert"
                             values={{innsendelsesfrist: formatDato(dokumentasjonEtterspurt.innsendelsesfrist!)}}
                         />
-                    </Normaltekst>
+                    </BodyShort>
                 )}
                 {dokumentasjonEtterspurt.oppgaveElementer.map((oppgaveElement, oppgaveElementIndex) => {
                     let {typeTekst, tilleggsinfoTekst} = getVisningstekster(
@@ -239,7 +238,6 @@ const DokumentasjonEtterspurtView: React.FC<Props> = ({dokumentasjonEtterspurt, 
                         />
                     );
                 })}
-
                 {listeOverDokumentasjonEtterspurtIderSomFeiletPaBackend.includes(dokumentasjonEtterspurt.oppgaveId) && (
                     <ErrorMessage className="oppgaver_vedlegg_feilmelding" style={{marginBottom: "1rem"}}>
                         <FormattedMessage id={"vedlegg.opplasting_backend_feilmelding"} />

--- a/src/components/oppgaver/DokumentasjonKravView.tsx
+++ b/src/components/oppgaver/DokumentasjonKravView.tsx
@@ -13,10 +13,9 @@ import {antallDagerEtterFrist} from "./Oppgaver";
 import {onSendVedleggClicked} from "./onSendVedleggClickedNew";
 import {FormattedMessage} from "react-intl";
 import {hentDokumentasjonkravMedId, hentInnsynsdata, innsynsdataUrl} from "../../redux/innsynsdata/innsynsDataActions";
-import {Normaltekst} from "nav-frontend-typografi";
 import {formatDato} from "../../utils/formatting";
 import {fileUploadFailedEvent} from "../../utils/amplitude";
-import {Button, Loader} from "@navikt/ds-react";
+import {BodyShort, Button, Loader} from "@navikt/ds-react";
 import {ErrorMessage} from "../errors/ErrorMessage";
 
 interface Props {
@@ -226,22 +225,21 @@ const DokumentasjonKravView: React.FC<Props> = ({dokumentasjonkrav, dokumentasjo
                 }
             >
                 {dokumentasjonkrav.frist && antallDagerSidenFristBlePassert <= 0 && (
-                    <Normaltekst className="luft_under_8px">
+                    <BodyShort spacing>
                         <FormattedMessage
                             id="oppgaver.innsendelsesfrist"
                             values={{innsendelsesfrist: formatDato(dokumentasjonkrav.frist!)}}
                         />
-                    </Normaltekst>
+                    </BodyShort>
                 )}
                 {dokumentasjonkrav.frist && antallDagerSidenFristBlePassert > 0 && (
-                    <Normaltekst className="luft_under_8px">
+                    <BodyShort spacing>
                         <FormattedMessage
                             id="oppgaver.innsendelsesfrist_passert"
                             values={{innsendelsesfrist: formatDato(dokumentasjonkrav.frist!)}}
                         />
-                    </Normaltekst>
+                    </BodyShort>
                 )}
-
                 {dokumentasjonkrav.dokumentasjonkravElementer.map(
                     (dokumentasjonkravElement, dokumentasjonkravElementIndex) => {
                         return (

--- a/src/components/oppgaver/DokumentasjonkravElementView.tsx
+++ b/src/components/oppgaver/DokumentasjonkravElementView.tsx
@@ -4,13 +4,13 @@ import {alertUser} from "../../utils/vedleggUtils";
 import {useSelector} from "react-redux";
 import {InnsynAppState} from "../../redux/reduxTypes";
 import AddFileButton from "./AddFileButton";
-import {Element, Normaltekst} from "nav-frontend-typografi";
 import {isFileUploadAllowed} from "../driftsmelding/DriftsmeldingUtilities";
 import {v4 as uuidv4} from "uuid";
 import FileItemView from "./FileItemView";
 import ErrorMessage from "./ErrorMessage";
 import {ErrorMessageTitle} from "./ErrorMessageTitleNew";
 import {validateFile} from "./validateFile";
+import {BodyShort, Label} from "@navikt/ds-react";
 
 export interface FileValidationErrors {
     errors: Set<string>;
@@ -76,11 +76,11 @@ const DokumentasjonkravElementView: React.FC<{
         <div className={"oppgaver_detalj" + (visOppgaverDetaljeFeil ? " oppgaver_detalj_feil" : "")}>
             <div className={"oppgave-detalj-overste-linje"}>
                 <div className={"tekst-wrapping"}>
-                    <Element>{dokumentasjonkravElement.tittel}</Element>
+                    <Label>{dokumentasjonkravElement.tittel}</Label>
                 </div>
                 {dokumentasjonkravElement.beskrivelse && (
                     <div className={"tekst-wrapping"}>
-                        <Normaltekst className="luft_over_4px">{dokumentasjonkravElement.beskrivelse}</Normaltekst>
+                        <BodyShort>{dokumentasjonkravElement.beskrivelse}</BodyShort>
                     </div>
                 )}
                 {canUploadAttatchemnts && (

--- a/src/components/oppgaver/FileItemView.tsx
+++ b/src/components/oppgaver/FileItemView.tsx
@@ -5,9 +5,8 @@ import {Fil} from "../../redux/innsynsdata/innsynsdataReducer";
 import {formatBytes} from "../../utils/formatting";
 import VedleggModal from "./VedleggModal";
 import {FormattedMessage} from "react-intl";
-import {Element} from "nav-frontend-typografi";
 import {REST_STATUS} from "../../utils/restUtils";
-import {Button, Link} from "@navikt/ds-react";
+import {Button, Label, Link} from "@navikt/ds-react";
 import {ErrorMessage} from "../errors/ErrorMessage";
 
 type ClickEvent = React.MouseEvent<HTMLAnchorElement, MouseEvent> | React.MouseEvent<HTMLButtonElement, MouseEvent>;
@@ -45,9 +44,9 @@ const FileItemView: React.FC<{
                 </div>
                 <div className="fjern_lenkeboks">
                     <Button variant="tertiary" size="small" onClick={(event) => onDelete(event, fil)}>
-                        <Element>
+                        <Label>
                             <FormattedMessage id="vedlegg.fjern" />
-                        </Element>
+                        </Label>
                         <TrashBin className="klikkbar_soppelboette" />
                     </Button>
                 </div>

--- a/src/components/oppgaver/IngenOppgaverPanel.tsx
+++ b/src/components/oppgaver/IngenOppgaverPanel.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import TodoList from "../ikoner/TodoList";
-import {Element, Normaltekst} from "nav-frontend-typografi";
 import {FormattedMessage} from "react-intl";
 import PaperClip from "../ikoner/PaperClip";
 import {useSelector} from "react-redux";
@@ -13,6 +12,7 @@ import {
 } from "../../redux/innsynsdata/innsynsdataReducer";
 import Panel from "nav-frontend-paneler";
 import {getSkalViseVilkarView} from "../vilkar/VilkarUtils";
+import {BodyShort, Label} from "@navikt/ds-react";
 
 interface Props {
     dokumentasjonEtterspurt: DokumentasjonEtterspurt[] | null;
@@ -47,12 +47,12 @@ const IngenOppgaverPanel: React.FC<Props> = ({dokumentasjonkrav, vilkar, dokumen
                         <TodoList />
                     </span>
                     <div style={{paddingLeft: "38px"}}>
-                        <Element>
+                        <Label>
                             <FormattedMessage id="oppgaver.ingen_oppgaver" />
-                        </Element>
-                        <Normaltekst>
+                        </Label>
+                        <BodyShort>
                             <FormattedMessage id="oppgaver.beskjed" />
-                        </Normaltekst>
+                        </BodyShort>
                     </div>
                 </div>
                 <div style={{marginTop: "20px"}}>
@@ -60,12 +60,12 @@ const IngenOppgaverPanel: React.FC<Props> = ({dokumentasjonkrav, vilkar, dokumen
                         <PaperClip />
                     </span>
                     <div style={{paddingLeft: "38px"}}>
-                        <Element>
+                        <Label>
                             <FormattedMessage id="oppgaver.andre_dokumenter" />
-                        </Element>
-                        <Normaltekst>
+                        </Label>
+                        <BodyShort>
                             <FormattedMessage id="oppgaver.andre_dokumenter_beskjed" />
-                        </Normaltekst>
+                        </BodyShort>
                     </div>
                 </div>
             </Panel>

--- a/src/components/oppgaver/Oppgaver.tsx
+++ b/src/components/oppgaver/Oppgaver.tsx
@@ -1,5 +1,4 @@
 import Panel from "nav-frontend-paneler";
-import {Element, Normaltekst, Systemtittel} from "nav-frontend-typografi";
 import React from "react";
 import DokumentBinder from "../ikoner/DocumentBinder";
 import "./oppgaver.less";
@@ -18,7 +17,7 @@ import {InnsynAppState} from "../../redux/reduxTypes";
 import DokumentasjonKravView from "./DokumentasjonKravView";
 import {VilkarView} from "./VilkarView";
 import {logButtonOrLinkClick} from "../../utils/amplitude";
-import {Accordion} from "@navikt/ds-react";
+import {Accordion, BodyShort, Heading, Label} from "@navikt/ds-react";
 import styled from "styled-components";
 
 const StyledAccordion = styled(Accordion)`
@@ -73,9 +72,9 @@ const Oppgaver = () => {
     return (
         <>
             <Panel className="panel-luft-over">
-                <Systemtittel>
+                <Heading level="2" size="medium">
                     <FormattedMessage id="oppgaver.dine_oppgaver" />
-                </Systemtittel>
+                </Heading>
             </Panel>
 
             <OppgaveInformasjon />
@@ -116,15 +115,15 @@ const Oppgaver = () => {
                                     <div className="oppgaver_header">
                                         <DokumentBinder />
                                         <div>
-                                            <Element>
+                                            <Label>
                                                 {dokumentasjonEtterspurtErFraInnsyn && (
                                                     <FormattedMessage id="oppgaver.maa_sende_dok_veileder" />
                                                 )}
                                                 {!dokumentasjonEtterspurtErFraInnsyn && (
                                                     <FormattedMessage id="oppgaver.maa_sende_dok" />
                                                 )}
-                                            </Element>
-                                            <Normaltekst>
+                                            </Label>
+                                            <BodyShort>
                                                 {dokumentasjonEtterspurtErFraInnsyn &&
                                                     antallDagerSidenFristBlePassert <= 0 && (
                                                         <FormattedMessage
@@ -152,19 +151,19 @@ const Oppgaver = () => {
                                                             }}
                                                         />
                                                     )}
-                                            </Normaltekst>
+                                            </BodyShort>
                                         </div>
                                     </div>
                                 </Accordion.Header>
                                 <Accordion.Content>
                                     {dokumentasjonEtterspurtErFraInnsyn ? (
-                                        <Normaltekst>
+                                        <BodyShort>
                                             <FormattedMessage id="oppgaver.veileder_trenger_mer" />
-                                        </Normaltekst>
+                                        </BodyShort>
                                     ) : (
-                                        <Normaltekst>
+                                        <BodyShort>
                                             <FormattedMessage id="oppgaver.last_opp_vedlegg_ikke" />
-                                        </Normaltekst>
+                                        </BodyShort>
                                     )}
 
                                     <OpplastingAvVedleggModal />
@@ -196,15 +195,15 @@ const Oppgaver = () => {
                                     <div className="oppgaver_header">
                                         <DokumentBinder />
                                         <div>
-                                            <Element>{<FormattedMessage id="vilkar.du_har_vilkar" />}</Element>
-                                            <Normaltekst>
+                                            <Label>{<FormattedMessage id="vilkar.du_har_vilkar" />}</Label>
+                                            <BodyShort>
                                                 <FormattedMessage
                                                     id="vilkar.veileder_trenger_mer"
                                                     values={{
                                                         antallVilkar: vilkar.length,
                                                     }}
                                                 />
-                                            </Normaltekst>
+                                            </BodyShort>
                                         </div>
                                     </div>
                                 </Accordion.Header>
@@ -226,10 +225,10 @@ const Oppgaver = () => {
                                     <div className="oppgaver_header">
                                         <DokumentBinder />
                                         <div>
-                                            <Element>
+                                            <Label>
                                                 <FormattedMessage id="dokumentasjonkrav.dokumentasjon_stonad" />
-                                            </Element>
-                                            <Normaltekst>
+                                            </Label>
+                                            <BodyShort>
                                                 <FormattedMessage
                                                     id="dokumentasjonkrav.veileder_trenger_mer"
                                                     values={{
@@ -249,7 +248,7 @@ const Oppgaver = () => {
                                                                 : "dokument",
                                                     }}
                                                 />
-                                            </Normaltekst>
+                                            </BodyShort>
                                         </div>
                                     </div>
                                 </Accordion.Header>

--- a/src/components/oppgaver/OpplastingAvVedleggModal.tsx
+++ b/src/components/oppgaver/OpplastingAvVedleggModal.tsx
@@ -1,7 +1,6 @@
 import React, {useState, MouseEvent} from "react";
 import {FormattedMessage} from "react-intl";
-import {Systemtittel, Undertittel} from "nav-frontend-typografi";
-import {Link, Modal} from "@navikt/ds-react";
+import {BodyShort, Heading, Link, Modal} from "@navikt/ds-react";
 import styled from "styled-components";
 
 const StyledModal = styled(Modal)`
@@ -29,52 +28,58 @@ export const OpplastingAvVedleggModal = () => {
                 }}
             >
                 <Modal.Content>
-                    <Systemtittel>
+                    <Heading level="2" size="medium" spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.overskrift" />
-                    </Systemtittel>
+                    </Heading>
 
-                    <Undertittel>
+                    <Heading level="3" size="small" spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk1.tittel" />
-                    </Undertittel>
-                    <p>
+                    </Heading>
+                    <BodyShort spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk1.avsnitt1" />
-                    </p>
-                    <p>
+                    </BodyShort>
+                    <BodyShort spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk1.avsnitt2" />
-                    </p>
-                    <p>
+                    </BodyShort>
+                    <BodyShort spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk1.avsnitt3" />
-                    </p>
+                    </BodyShort>
 
-                    <Undertittel>
+                    <Heading level="3" size="small" spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk2.tittel" />
-                    </Undertittel>
-                    <p>
+                    </Heading>
+                    <BodyShort spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk2.avsnitt1" />
-                    </p>
+                    </BodyShort>
 
-                    <Undertittel>
+                    <Heading level="3" size="small" spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk3.tittel" />
-                    </Undertittel>
-                    <p>
+                    </Heading>
+                    <BodyShort spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk3.avsnitt1" />
-                    </p>
+                    </BodyShort>
 
-                    <Undertittel>
+                    <Heading level="3" size="small" spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk4.tittel" />
-                    </Undertittel>
-                    <p>
+                    </Heading>
+                    <BodyShort spacing>
                         <FormattedMessage id="oppgaver.informasjon.modal.bolk4.avsnitt1" />
-                    </p>
+                    </BodyShort>
                     <ul>
                         <li>
-                            <FormattedMessage id="oppgaver.informasjon.modal.bolk4.liste1" />
+                            <BodyShort>
+                                <FormattedMessage id="oppgaver.informasjon.modal.bolk4.liste1" />
+                            </BodyShort>
                         </li>
                         <li>
-                            <FormattedMessage id="oppgaver.informasjon.modal.bolk4.liste2" />
+                            <BodyShort>
+                                <FormattedMessage id="oppgaver.informasjon.modal.bolk4.liste2" />
+                            </BodyShort>
                         </li>
                         <li>
-                            <FormattedMessage id="oppgaver.informasjon.modal.bolk4.liste3" />
+                            <BodyShort>
+                                <FormattedMessage id="oppgaver.informasjon.modal.bolk4.liste3" />
+                            </BodyShort>
                         </li>
                     </ul>
                 </Modal.Content>

--- a/src/components/oppgaver/VilkarView.tsx
+++ b/src/components/oppgaver/VilkarView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {Vilkar} from "../../redux/innsynsdata/innsynsdataReducer";
-import {Element, Normaltekst} from "nav-frontend-typografi";
+import {BodyShort, Label} from "@navikt/ds-react";
 
 interface Props {
     vilkar: Vilkar;
@@ -11,11 +11,11 @@ export const VilkarView: React.FC<Props> = ({vilkar}) => {
         <div className={"oppgaver_detaljer luft_over_1rem"}>
             <div className={"oppgave-detalj-overste-linje"}>
                 <div className={"tekst-wrapping"}>
-                    <Element>{vilkar.tittel}</Element>
+                    <Label>{vilkar.tittel}</Label>
                 </div>
                 {vilkar.beskrivelse && (
                     <div className={"tekst-wrapping"}>
-                        <Normaltekst className="luft_over_4px">{vilkar.beskrivelse}</Normaltekst>
+                        <BodyShort>{vilkar.beskrivelse}</BodyShort>
                     </div>
                 )}
             </div>

--- a/src/components/paneler/EkspanderbartIkonPanel.tsx
+++ b/src/components/paneler/EkspanderbartIkonPanel.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import Panel from "nav-frontend-paneler";
 import DocumentChecklist from "../ikoner/DocumentChecklist";
-import {Element, Normaltekst} from "nav-frontend-typografi";
 import DokumentBinder from "../ikoner/DocumentBinder";
-import {Accordion} from "@navikt/ds-react";
+import {Accordion, BodyShort, Label} from "@navikt/ds-react";
 import styled from "styled-components";
 
 const StyledAccordion = styled(Accordion)`
@@ -30,8 +29,8 @@ const EkspanderbartIkonPanel: React.FC<Props> = ({tittel, underTittel, ikon, chi
             {ikon === PanelIkon.CHECKLIST && <DocumentChecklist />}
             {ikon === PanelIkon.BINDERS && <DokumentBinder />}
             <div>
-                <Element>{tittel}</Element>
-                <Normaltekst>{underTittel}</Normaltekst>
+                <Label>{tittel}</Label>
+                <BodyShort>{underTittel}</BodyShort>
             </div>
         </div>
     );

--- a/src/components/sideIkkeFunnet/SideIkkeFunnet.less
+++ b/src/components/sideIkkeFunnet/SideIkkeFunnet.less
@@ -21,29 +21,15 @@
 
     &__ikon {
         margin-top: 40px;
-    }
-
-    &__tittel {
-        color: @navGra60;
         margin-bottom: 2rem;
-        padding-top: 3rem;
     }
 
-    &__innhold {
-        margin-bottom: 20px;
-    }
-
-    &__feilkode {
-        margin-bottom: 3rem;
-        margin-top: 1rem;
-    }
-
-    &__link-liste {
+    ul {
         margin-top: 20px;
         padding-left: 0;
     }
 
-    &__link {
+    li {
         display: inline-block;
         margin-top: 20px;
         padding-left: 30px;

--- a/src/components/sideIkkeFunnet/SideIkkeFunnet.tsx
+++ b/src/components/sideIkkeFunnet/SideIkkeFunnet.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import UtropstegnSirkelGraIkon from "./UtropstegnSirkelGraIkon";
-import {Innholdstittel} from "nav-frontend-typografi";
 import "./SideIkkeFunnet.less";
+import {BodyShort, Heading, Link} from "@navikt/ds-react";
 
 const SideIkkeFunnet: React.FC<{}> = () => {
     return (
@@ -9,27 +9,22 @@ const SideIkkeFunnet: React.FC<{}> = () => {
             <div className="sideIkkeFunnet__ikon">
                 <UtropstegnSirkelGraIkon />
             </div>
-            <Innholdstittel className="sideIkkeFunnet__tittel">OOPS, NOE GIKK GALT</Innholdstittel>
-            <div className="sideIkkeFunnet__innhold">Vi fant ikke siden du prøvde å åpne</div>
+            <Heading level="1" size="xlarge" spacing>
+                OOPS, NOE GIKK GALT
+            </Heading>
+            <BodyShort spacing>Vi fant ikke siden du prøvde å åpne</BodyShort>
 
-            <ul className="sideIkkeFunnet__link-liste">
-                <li className="sideIkkeFunnet__link">
-                    <a href="http://www.nav.no" className="lenke">
-                        Gå til forsiden nav.no
-                    </a>
+            <ul>
+                <li>
+                    <Link href="http://www.nav.no">Gå til forsiden nav.no</Link>
                 </li>
-                <li className="sideIkkeFunnet__link">
-                    <a href="https://www.nav.no/no/Ditt+NAV" className="lenke">
-                        Gå til Ditt NAV
-                    </a>
+                <li>
+                    <Link href="https://www.nav.no/no/Ditt+NAV">Gå til Ditt NAV</Link>
                 </li>
-                <li className="sideIkkeFunnet__link">
-                    <a
-                        href="https://www.nav.no/no/NAV+og+samfunn/Kontakt+NAV/Klage+ris+og+ros/Feil+og+mangler+paa+navno"
-                        className="lenke"
-                    >
+                <li>
+                    <Link href="https://www.nav.no/person/kontakt-oss/nb/tilbakemeldinger/feil-og-mangler">
                         Meld fra om feil
-                    </a>
+                    </Link>
                 </li>
             </ul>
         </div>

--- a/src/components/sideIkkeFunnet/SideIkkeFunnet.tsx
+++ b/src/components/sideIkkeFunnet/SideIkkeFunnet.tsx
@@ -16,7 +16,7 @@ const SideIkkeFunnet: React.FC<{}> = () => {
 
             <ul>
                 <li>
-                    <Link href="http://www.nav.no">Gå til forsiden nav.no</Link>
+                    <Link href="https://www.nav.no">Gå til forsiden nav.no</Link>
                 </li>
                 <li>
                     <Link href="https://www.nav.no/no/Ditt+NAV">Gå til Ditt NAV</Link>

--- a/src/components/soknadsStatus/SoknadsStatus.tsx
+++ b/src/components/soknadsStatus/SoknadsStatus.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Panel from "nav-frontend-paneler";
-import {Element, Innholdstittel, Normaltekst} from "nav-frontend-typografi";
 import "./soknadsStatus.less";
 import {SaksStatus, SaksStatusState, VedtakFattet} from "../../redux/innsynsdata/innsynsdataReducer";
 import EksternLenke from "../eksternLenke/EksternLenke";
@@ -15,7 +14,7 @@ import DokumentMottatt from "../ikoner/DokumentMottatt";
 import DokumentElla from "../ikoner/DocumentElla";
 import {EtikettLiten} from "../etikett/EtikettLiten";
 import {logButtonOrLinkClick} from "../../utils/amplitude";
-import {Alert} from "@navikt/ds-react";
+import {Alert, BodyShort, Heading, Label} from "@navikt/ds-react";
 
 export const hentSaksStatusTittel = (saksStatus: SaksStatus) => {
     switch (saksStatus) {
@@ -51,7 +50,9 @@ const SoknadsStatus: React.FC<Props> = ({status, sak, restStatus}) => {
                 {skalViseLastestripe(restStatus) && <Lastestriper linjer={1} />}
                 {restStatus !== REST_STATUS.FEILET && (
                     <>
-                        <Innholdstittel>{soknadsStatusTittel(status, intl)}</Innholdstittel>
+                        <Heading level="1" size="xlarge">
+                            {soknadsStatusTittel(status, intl)}
+                        </Heading>
                         {status === SoknadsStatusEnum.SENDT && <DokumentSendt />}
                         {status === SoknadsStatusEnum.MOTTATT && <DokumentMottatt />}
                         {status === SoknadsStatusEnum.UNDER_BEHANDLING && <DokumentElla />}
@@ -87,7 +88,7 @@ const SoknadsStatus: React.FC<Props> = ({status, sak, restStatus}) => {
                         <div className="status_detalj_panel" key={index}>
                             <div className={"status_detalj_linje"}>
                                 <div className="status_detalj_panel__tittel">
-                                    <Element>{statusdetalj.tittel}</Element>
+                                    <Label>{statusdetalj.tittel}</Label>
                                 </div>
                                 <div className="status_detalj_panel__status">
                                     <EtikettLiten>
@@ -101,21 +102,21 @@ const SoknadsStatus: React.FC<Props> = ({status, sak, restStatus}) => {
                             </div>
                             {statusdetalj.melding && statusdetalj.melding.length > 0 && (
                                 <div className="panel-glippe-over">
-                                    <Normaltekst>{statusdetalj.melding}</Normaltekst>
+                                    <BodyShort>{statusdetalj.melding}</BodyShort>
                                 </div>
                             )}
                             {sakBehandlesIkke && !soknadBehandlesIkke && (
                                 <div className="panel-glippe-over">
-                                    <Normaltekst>
+                                    <BodyShort>
                                         <FormattedMessage id="status.sak_behandles_ikke_ingress" />
-                                    </Normaltekst>
+                                    </BodyShort>
                                 </div>
                             )}
                             {sakIkkeInnsyn && !soknadBehandlesIkke && (
                                 <div className="panel-glippe-over">
-                                    <Normaltekst>
+                                    <BodyShort>
                                         <FormattedMessage id="status.ikke_innsyn_ingress" />
-                                    </Normaltekst>
+                                    </BodyShort>
                                 </div>
                             )}
 

--- a/src/components/soknadsStatus/SoknadsStatusUtenInnsyn.tsx
+++ b/src/components/soknadsStatus/SoknadsStatusUtenInnsyn.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Panel from "nav-frontend-paneler";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
 import "./soknadsStatus.less";
 import {UrlResponse} from "../../redux/innsynsdata/innsynsdataReducer";
 import EksternLenke from "../eksternLenke/EksternLenke";
@@ -9,6 +8,7 @@ import Lastestriper from "../lastestriper/Lasterstriper";
 import {REST_STATUS, skalViseLastestripe} from "../../utils/restUtils";
 import DokumentSendt from "../ikoner/DokumentSendt";
 import DatoOgKlokkeslett from "../tidspunkt/DatoOgKlokkeslett";
+import {BodyShort, Heading} from "@navikt/ds-react";
 
 const SoknadsStatusUtenInnsyn = (props: {
     restStatus: REST_STATUS;
@@ -22,7 +22,9 @@ const SoknadsStatusUtenInnsyn = (props: {
                 {skalViseLastestripe(props.restStatus) && <Lastestriper linjer={1} />}
                 {props.restStatus !== REST_STATUS.FEILET && (
                     <>
-                        <Innholdstittel>Søknaden er sendt</Innholdstittel>
+                        <Heading level="1" size="xlarge">
+                            Søknaden er sendt
+                        </Heading>
                         <DokumentSendt />
                     </>
                 )}
@@ -30,14 +32,14 @@ const SoknadsStatusUtenInnsyn = (props: {
 
             <div className="status_detalj_panel_info_alert_luft_under">
                 {props.tidspunktSendt && props.navKontor && props.filUrl && (
-                    <Normaltekst>
+                    <BodyShort>
                         Sendt den{" "}
                         <DatoOgKlokkeslett bareDato={true} tidspunkt={props.tidspunktSendt} brukKortMaanedNavn={true} />
                         til {props.navKontor}{" "}
                         <EksternLenke href={props.filUrl.link} target="_blank">
                             {props.filUrl.linkTekst}
                         </EksternLenke>
-                    </Normaltekst>
+                    </BodyShort>
                 )}
             </div>
         </Panel>

--- a/src/components/vedlegg/EttersendelseView.tsx
+++ b/src/components/vedlegg/EttersendelseView.tsx
@@ -1,5 +1,4 @@
 import React, {useEffect, useState} from "react";
-import {Element, Normaltekst} from "nav-frontend-typografi";
 import {
     Fil,
     InnsynsdataActionTypeKeys,
@@ -27,7 +26,7 @@ import {v4 as uuidv4} from "uuid";
 import FileItemView from "../oppgaver/FileItemView";
 import {setFileUploadFailedVirusCheckInBackend} from "../../redux/innsynsdata/innsynsDataActions";
 import {logButtonOrLinkClick} from "../../utils/amplitude";
-import {Button, Loader} from "@navikt/ds-react";
+import {BodyShort, Button, Label, Loader} from "@navikt/ds-react";
 import {ErrorMessage} from "../errors/ErrorMessage";
 
 /*
@@ -165,12 +164,12 @@ const EttersendelseView: React.FC<Props> = ({restStatus}) => {
                         }
                         style={{marginTop: "0px"}}
                     >
-                        <Element>
+                        <Label>
                             <FormattedMessage id="andre_vedlegg.type" />
-                        </Element>
-                        <Normaltekst className="luft_over_4px">
+                        </Label>
+                        <BodyShort>
                             <FormattedMessage id="andre_vedlegg.tilleggsinfo" />
-                        </Normaltekst>
+                        </BodyShort>
 
                         {kanLasteOppVedlegg && (
                             <AddFileButton onChange={onChange} referanse={BACKEND_FEIL_ID} id={uuid} />

--- a/src/components/vilkar/OppgaveInformasjon.tsx
+++ b/src/components/vilkar/OppgaveInformasjon.tsx
@@ -4,11 +4,11 @@ import {useSelector} from "react-redux";
 import {InnsynAppState} from "../../redux/reduxTypes";
 import {SaksStatusState} from "../../redux/innsynsdata/innsynsdataReducer";
 import {FormattedMessage} from "react-intl";
-import {Element, Normaltekst} from "nav-frontend-typografi";
 import BinderSmall from "../ikoner/BinderSmall";
 import ChecklistSmall from "../ikoner/ChecklistSmall";
 import EkspanderbartIkonPanel, {PanelIkon} from "../paneler/EkspanderbartIkonPanel";
 import "./vilkar.less";
+import {BodyShort, Label} from "@navikt/ds-react";
 
 const OppgaveInformasjon: React.FC = () => {
     const innsynSaksStatusListe: SaksStatusState[] = useSelector(
@@ -28,12 +28,12 @@ const OppgaveInformasjon: React.FC = () => {
                         <ChecklistSmall />
                     </div>
                     <div className={"vilkar-bolk-tekst-wrapper"}>
-                        <Element>
+                        <Label>
                             <FormattedMessage id={"oppgaver.vilkar"} />
-                        </Element>
-                        <Normaltekst>
+                        </Label>
+                        <BodyShort>
                             <FormattedMessage id={"oppgaver.vilkar.beskrivelse"} />
-                        </Normaltekst>
+                        </BodyShort>
                     </div>
                 </div>
                 <div className={"vilkar-bolk-med-symbol-wrapper"}>
@@ -41,12 +41,12 @@ const OppgaveInformasjon: React.FC = () => {
                         <BinderSmall />
                     </div>
                     <div className={"vilkar-bolk-tekst-wrapper"}>
-                        <Element>
+                        <Label>
                             <FormattedMessage id={"oppgaver.vilkar.dokumentasjonskrav"} />
-                        </Element>
-                        <Normaltekst>
+                        </Label>
+                        <BodyShort>
                             <FormattedMessage id={"oppgaver.vilkar.dokumentasjonskrav.beskrivelse"} />
-                        </Normaltekst>
+                        </BodyShort>
                     </div>
                 </div>
             </EkspanderbartIkonPanel>

--- a/src/index.less
+++ b/src/index.less
@@ -1,22 +1,7 @@
 @import "../node_modules/nav-frontend-core/less/core";
 @import "../node_modules/nav-frontend-paneler-style/src/index.less";
-@import "../node_modules/nav-frontend-typografi-style/src/index.less";
 
 @import "./components/paneler/paneler.less";
-
-//Grunnet ulike font-størrelse mellom nav-frontend og ds-react
-//nullstilles font foreløpig
-:root {
-    --navds-font-size-heading-2xlarge: 2.2222222222222223rem;
-    --navds-font-size-heading-xlarge: 1.7777777777777777rem;
-    --navds-font-size-heading-large: 1.5555555555555556rem;
-    --navds-font-size-heading-medium: 1.3333333333333333rem;
-    --navds-font-size-heading-small: 1.1111111111111112rem;
-    --navds-font-size-xlarge: 1.1111111111111112rem;
-    --navds-font-size-large: 1rem;
-    --navds-font-size-medium: 0.8888888888888888rem;
-    --navds-font-size-small: 0.7777777777777778rem;
-}
 
 body {
     margin: 0;

--- a/src/innsyn/SaksStatus.tsx
+++ b/src/innsyn/SaksStatus.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {useDispatch, useSelector} from "react-redux";
-import {Alert} from "@navikt/ds-react";
+import {Alert, BodyShort, Heading} from "@navikt/ds-react";
 import {InnsynAppState} from "../redux/reduxTypes";
 import {REST_STATUS} from "../utils/restUtils";
 import {hentInnsynsdata} from "../redux/innsynsdata/innsynsDataActions";
@@ -20,7 +20,6 @@ import ForelopigSvarAlertstripe from "../components/forelopigSvar/ForelopigSvar"
 import DriftsmeldingAlertstripe from "../components/driftsmelding/Driftsmelding";
 import Brodsmulesti, {UrlType} from "../components/brodsmuleSti/BrodsmuleSti";
 import Panel from "nav-frontend-paneler";
-import {Normaltekst, Systemtittel} from "nav-frontend-typografi";
 import {SoknadMedInnsynHotjarTrigger, SoknadUtenInnsynHotjarTrigger} from "../components/hotjarTrigger/HotjarTrigger";
 import {isKommuneMedInnsyn, isKommuneUtenInnsyn} from "./saksStatusUtils";
 import {useBannerTittel} from "../redux/navigasjon/navigasjonUtils";
@@ -131,8 +130,8 @@ const SaksStatusView: React.FC<Props> = ({match}) => {
         <>
             {!leserData(restStatus.saksStatus) && sakStatusHarFeilet && (
                 <Alert variant="warning" className="luft_over_16px">
-                    <Normaltekst>Vi klarte ikke å hente inn all informasjonen på siden.</Normaltekst>
-                    <Normaltekst>Du kan forsøke å oppdatere siden, eller prøve igjen senere.</Normaltekst>
+                    <BodyShort>Vi klarte ikke å hente inn all informasjonen på siden.</BodyShort>
+                    <BodyShort>Du kan forsøke å oppdatere siden, eller prøve igjen senere.</BodyShort>
                 </Alert>
             )}
             <Brodsmulesti
@@ -188,9 +187,9 @@ const SaksStatusView: React.FC<Props> = ({match}) => {
                     {kommuneResponse != null && kommuneResponse.erInnsynDeaktivert && (
                         <>
                             <Panel className="panel-luft-over">
-                                <Systemtittel>
+                                <Heading level="2" size="medium">
                                     <FormattedMessage id="vedlegg.tittel" />
-                                </Systemtittel>
+                                </Heading>
                             </Panel>
                             <Panel className="panel-glippe-over">
                                 <VedleggView vedlegg={innsynsdata.vedlegg} restStatus={restStatus.vedlegg} />

--- a/src/saksoversikt/Saksoversikt.tsx
+++ b/src/saksoversikt/Saksoversikt.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from "react";
-import {Alert, LinkPanel} from "@navikt/ds-react";
+import {Alert, BodyShort, LinkPanel} from "@navikt/ds-react";
 import "./saksoversikt.less";
 import {InnsynAppState} from "../redux/reduxTypes";
 import {useDispatch, useSelector} from "react-redux";
@@ -11,7 +11,6 @@ import BigBanner from "../components/banner/BigBanner";
 import useSoknadsSakerService from "./sakerFraSoknad/useSoknadsSakerService";
 import {useBannerTittel} from "../redux/navigasjon/navigasjonUtils";
 import SaksoversiktIngenSoknader from "./SaksoversiktIngenSoknader";
-import {Normaltekst} from "nav-frontend-typografi";
 import {logAmplitudeEvent} from "../utils/amplitude";
 import styled from "styled-components";
 import {useCookies} from "react-cookie";
@@ -97,8 +96,8 @@ const Saksoversikt: React.FC = () => {
                     <>
                         {(innsynApiKommunikasjonsProblemer || soknadApiKommunikasjonsProblemer) && (
                             <Alert variant="warning" className="luft_over_16px">
-                                <Normaltekst>Vi klarte ikke å hente inn all informasjonen på siden.</Normaltekst>
-                                <Normaltekst>Du kan forsøke å oppdatere siden, eller prøve igjen senere.</Normaltekst>
+                                <BodyShort>Vi klarte ikke å hente inn all informasjonen på siden.</BodyShort>
+                                <BodyShort>Du kan forsøke å oppdatere siden, eller prøve igjen senere.</BodyShort>
                             </Alert>
                         )}
                         {kommunenummer.length > 0 &&

--- a/src/saksoversikt/SaksoversiktDineSaker.tsx
+++ b/src/saksoversikt/SaksoversiktDineSaker.tsx
@@ -3,7 +3,6 @@ import Panel from "nav-frontend-paneler";
 import "./saksoversikt.less";
 import {isAfter, isBefore, subMonths} from "date-fns";
 import Subheader from "../components/subheader/Subheader";
-import {Normaltekst, Systemtittel, Undertittel} from "nav-frontend-typografi";
 import InfoPanel, {InfoPanelContainer} from "../components/Infopanel/InfoPanel";
 import SakPanel from "./sakpanel/SakPanel";
 import Paginering from "../components/paginering/Paginering";
@@ -14,7 +13,7 @@ import {REST_STATUS} from "../utils/restUtils";
 import DineUtbetalingerPanel from "./dineUtbetalinger/DineUtbetalingerPanel";
 import useUtbetalingerExistsService from "../utbetalinger/service/useUtbetalingerExistsService";
 import {logAmplitudeEvent} from "../utils/amplitude";
-import {Button, Select} from "@navikt/ds-react";
+import {BodyShort, Button, Heading, Select} from "@navikt/ds-react";
 
 const SaksoversiktDineSaker: React.FC<{saker: Sakstype[]}> = ({saker}) => {
     const [periode, setPeriode] = useState<string>("alle");
@@ -93,7 +92,9 @@ const SaksoversiktDineSaker: React.FC<{saker: Sakstype[]}> = ({saker}) => {
     return (
         <>
             <div className="dine_soknader_panel ">
-                <Systemtittel className="dine_soknader_panel_overskrift">Dine søknader</Systemtittel>
+                <Heading level="2" size="medium" className="dine_soknader_panel_overskrift">
+                    Dine søknader
+                </Heading>
                 <div className="knapp_og_periode_container">
                     <Button as="a" variant="primary" href="/sosialhjelp/soknad/informasjon">
                         Ny søknad
@@ -146,8 +147,10 @@ const SaksoversiktDineSaker: React.FC<{saker: Sakstype[]}> = ({saker}) => {
 
             {filtrerteSaker.length === 0 && (
                 <Panel className="panel-glippe-over">
-                    <Normaltekst>Vi finner ingen søknader for denne perioden.</Normaltekst>
-                    <Normaltekst>Har du søkt på papir, har vi dessverre ikke mulighet til å vise den her.</Normaltekst>
+                    <BodyShort spacing>Vi finner ingen søknader for denne perioden.</BodyShort>
+                    <BodyShort spacing>
+                        Har du søkt på papir, har vi dessverre ikke mulighet til å vise den her.
+                    </BodyShort>
                 </Panel>
             )}
 
@@ -155,7 +158,9 @@ const SaksoversiktDineSaker: React.FC<{saker: Sakstype[]}> = ({saker}) => {
                 {utbetalingerExists && <DineUtbetalingerPanel />}
 
                 <Subheader className="panel-luft-over">
-                    <Undertittel>Relatert informasjon</Undertittel>
+                    <Heading level="2" size="small">
+                        Relatert informasjon
+                    </Heading>
                 </Subheader>
 
                 <InfoPanelContainer>

--- a/src/saksoversikt/SaksoversiktIngenSoknader.tsx
+++ b/src/saksoversikt/SaksoversiktIngenSoknader.tsx
@@ -1,7 +1,6 @@
 import IngenSoknaderFunnet from "../components/ikoner/IngenSoknaderFunnet";
-import {Normaltekst, Systemtittel} from "nav-frontend-typografi";
 import React from "react";
-import {GuidePanel, LinkPanel} from "@navikt/ds-react";
+import {BodyShort, GuidePanel, Heading, LinkPanel} from "@navikt/ds-react";
 import styled from "styled-components";
 
 const StyledGuidePanel = styled(GuidePanel)`
@@ -18,12 +17,12 @@ const SaksoversiktIngenSoknader: React.FC = () => {
                 illustration={<IngenSoknaderFunnet />}
             >
                 <>
-                    <Systemtittel className="ingenSoknaderFunnetText">
+                    <Heading level="2" size="medium" spacing className="ingenSoknaderFunnetText">
                         Vi finner ingen digital søknad fra deg
-                    </Systemtittel>
-                    <Normaltekst className="ingenSoknaderFunnetText">
+                    </Heading>
+                    <BodyShort spacing className="ingenSoknaderFunnetText">
                         Vi kan dessverre ikke vise søknader som er sendt på papir.
-                    </Normaltekst>
+                    </BodyShort>
                 </>
             </StyledGuidePanel>
 

--- a/src/saksoversikt/banner/SaksoversiktBanner.tsx
+++ b/src/saksoversikt/banner/SaksoversiktBanner.tsx
@@ -2,17 +2,21 @@ import * as React from "react";
 import UserIcon from "./UserIcon";
 import "./saksoversiktBanner.less";
 import {getDittNavUrl} from "../../utils/restUtils";
-import {Link} from "@navikt/ds-react";
+import {BodyShort, Heading, Link} from "@navikt/ds-react";
 
 const SaksoversiktBanner: React.FC<{children: React.ReactNode} & {}> = ({children}) => {
     return (
         <div className="saksoversikt-banner">
             <div className="blokk-center">
-                <p className="saksoversikt-banner__brodsmulesti">
+                <div className="saksoversikt-banner__brodsmulesti">
                     <UserIcon />
-                    <Link href={getDittNavUrl()}>Ditt NAV</Link>&nbsp;/ Økonomisk sosialhjelp
-                </p>
-                <h1 className="saksoversikt-banner__tittel">{children}</h1>
+                    <BodyShort>
+                        <Link href={getDittNavUrl()}>Ditt NAV</Link> / Økonomisk sosialhjelp
+                    </BodyShort>
+                </div>
+                <Heading level="1" size="2xlarge" className="saksoversikt-banner__tittel">
+                    {children}
+                </Heading>
             </div>
         </div>
     );

--- a/src/saksoversikt/banner/saksoversiktBanner.less
+++ b/src/saksoversikt/banner/saksoversiktBanner.less
@@ -9,15 +9,10 @@
     align-items: center;
     border-bottom: 4px solid @navGronnLighten60;
 
-    &__tittel {
-        font-size: 32px;
-        font-weight: bold;
-    }
-
     &__brodsmulesti {
         display: flex;
         align-items: center;
-        font-size: 14px;
+        margin-bottom: 1rem;
     }
 }
 

--- a/src/saksoversikt/dineUtbetalinger/DineUtbetalingerPanel.tsx
+++ b/src/saksoversikt/dineUtbetalinger/DineUtbetalingerPanel.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import {Normaltekst, Systemtittel} from "nav-frontend-typografi";
 import HandCoinsIcon from "../../components/ikoner/HandCoins";
 import "./dineUtbetalingerPanel.less";
 import {push} from "connected-react-router";
 import {useDispatch} from "react-redux";
-import {LinkPanel} from "@navikt/ds-react";
+import {BodyShort, Heading, LinkPanel} from "@navikt/ds-react";
 
 const DineUtbetalingerPanel: React.FC<{}> = () => {
     const dispatch = useDispatch();
@@ -24,8 +23,10 @@ const DineUtbetalingerPanel: React.FC<{}> = () => {
             <div className="dine_utbetalinger_innhold">
                 <HandCoinsIcon />
                 <div>
-                    <Systemtittel>Dine utbetalinger</Systemtittel>
-                    <Normaltekst>Oversikt over dine utbetalinger for økonomisk sosialhjelp</Normaltekst>
+                    <Heading level="2" size="medium" spacing>
+                        Dine utbetalinger
+                    </Heading>
+                    <BodyShort>Oversikt over dine utbetalinger for økonomisk sosialhjelp</BodyShort>
                 </div>
             </div>
         </LinkPanel>

--- a/src/saksoversikt/sakpanel/SakPanel.tsx
+++ b/src/saksoversikt/sakpanel/SakPanel.tsx
@@ -1,5 +1,4 @@
 import React, {useEffect} from "react";
-import {Element} from "nav-frontend-typografi";
 import DatoOgKlokkeslett from "../../components/tidspunkt/DatoOgKlokkeslett";
 import DocumentIcon from "../../components/ikoner/DocumentIcon";
 import "./sakpanel.less";
@@ -9,7 +8,7 @@ import {push} from "connected-react-router";
 import Lastestriper from "../../components/lastestriper/Lasterstriper";
 import {hentSaksdetaljer} from "../../redux/innsynsdata/innsynsDataActions";
 import {EtikettLiten} from "../../components/etikett/EtikettLiten";
-import {LinkPanel, Tag} from "@navikt/ds-react";
+import {Label, LinkPanel, Tag} from "@navikt/ds-react";
 import styled from "styled-components";
 
 const StyledLinkPanel = styled(LinkPanel)`
@@ -106,7 +105,7 @@ const SakPanel: React.FC<Props> = ({
                             )}
                         </div>
                         {underLasting && <Lastestriper linjer={1} />}
-                        {!underLasting && <Element className="">{tittel}</Element>}
+                        {!underLasting && <Label>{tittel}</Label>}
                     </div>
                 </div>
                 <div className="sakpanel_innhold_etikett">

--- a/src/saksoversikt/sakpanel/sakpanel.less
+++ b/src/saksoversikt/sakpanel/sakpanel.less
@@ -48,7 +48,7 @@
 }
 
 .sakpanel_innhold_etikett {
-    min-width: 9rem;
+    min-width: 10rem;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/src/utbetalinger/SavnerUtbetalingPanel.tsx
+++ b/src/utbetalinger/SavnerUtbetalingPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import {Element, Normaltekst} from "nav-frontend-typografi";
 import InfoIkon from "../components/ikoner/InfoIkon";
+import {BodyShort, Label, Link} from "@navikt/ds-react";
 
 const SavnerUtbetalingPanel: React.FC = () => {
     return (
@@ -8,22 +8,22 @@ const SavnerUtbetalingPanel: React.FC = () => {
             <span className="infoIkon">
                 <InfoIkon />
             </span>
-            <Element className="blokk-xs">Savner du en utbetaling på denne siden?</Element>
-            <Normaltekst>Utbetalingsoversikten er under utvikling og vi kan for øyeblikket bare vise:</Normaltekst>
+            <Label spacing>Savner du en utbetaling på denne siden?</Label>
+            <BodyShort>Utbetalingsoversikten er under utvikling og vi kan for øyeblikket bare vise:</BodyShort>
             <ul>
                 <li>
-                    <Normaltekst>
+                    <BodyShort>
                         utbetalinger av økonomisk sosialhjelp,{" "}
-                        <a className="lenke" href="https://tjenester.nav.no/utbetalingsoversikt">
+                        <Link href="https://tjenester.nav.no/utbetalingsoversikt">
                             andre utbetalinger finner du her
-                        </a>
-                    </Normaltekst>
+                        </Link>
+                    </BodyShort>
                 </li>
                 <li>
-                    <Normaltekst>utbetalinger fra digitale søknader, men ikke fra papirsøknader</Normaltekst>
+                    <BodyShort>utbetalinger fra digitale søknader, men ikke fra papirsøknader</BodyShort>
                 </li>
                 <li>
-                    <Normaltekst>utbetalinger som er inntil ett år gamle</Normaltekst>
+                    <BodyShort>utbetalinger som er inntil ett år gamle</BodyShort>
                 </li>
             </ul>
         </div>

--- a/src/utbetalinger/UtbetalingEkspanderbart.tsx
+++ b/src/utbetalinger/UtbetalingEkspanderbart.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from "react";
-import {Normaltekst} from "nav-frontend-typografi";
 import EkspanderLink from "./EkspanderLink";
 import Collapsible from "react-collapsible";
+import {BodyShort} from "@navikt/ds-react";
 
 interface Props {
     tittel: string;
@@ -14,7 +14,7 @@ const UtbetalingEkspanderbart: React.FC<Props> = ({tittel, children, defaultOpen
     return (
         <>
             <div className="utbetaling_header">
-                <Normaltekst>{tittel}</Normaltekst>
+                <BodyShort>{tittel}</BodyShort>
                 <EkspanderLink open={open} setOpen={setOpen} />
             </div>
 

--- a/src/utbetalinger/Utbetalinger.tsx
+++ b/src/utbetalinger/Utbetalinger.tsx
@@ -11,11 +11,11 @@ import {
     filtrerUtbetalingerPaaMottaker,
 } from "./utbetalingerUtils";
 import Brodsmulesti, {UrlType} from "../components/brodsmuleSti/BrodsmuleSti";
-import {Sidetittel} from "nav-frontend-typografi";
 import {useDispatch} from "react-redux";
 import {hentSaksdata} from "../redux/innsynsdata/innsynsDataActions";
 import {InnsynsdataSti} from "../redux/innsynsdata/innsynsdataReducer";
 import {logAmplitudeEvent} from "../utils/amplitude";
+import {Heading} from "@navikt/ds-react";
 
 let DEFAULT_ANTALL_MND_VIST: number = 3;
 
@@ -80,7 +80,9 @@ const Utbetalinger: React.FC = () => {
             />
 
             <div className="utbetalinger">
-                <Sidetittel className="utbetalinger__overskrift">Utbetalingsoversikt</Sidetittel>
+                <Heading level="1" size="2xlarge" spacing className="utbetalinger__overskrift">
+                    Utbetalingsoversikt
+                </Heading>
                 <div className="utbetalinger_row">
                     <div className="utbetalinger_column">
                         <div className="utbetalinger_column_1">

--- a/src/utbetalinger/UtbetalingerPanel.tsx
+++ b/src/utbetalinger/UtbetalingerPanel.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import {Element, Undertittel} from "nav-frontend-typografi";
 import SavnerUtbetalingPanel from "./SavnerUtbetalingPanel";
 import UtbetalingEkspanderbart from "./UtbetalingEkspanderbart";
 import {UtbetalingMaaned, UtbetalingSakType} from "./service/useUtbetalingerService";
@@ -8,6 +7,7 @@ import Saksdetaljer from "./Saksdetaljer";
 import Lastestriper from "../components/lastestriper/Lasterstriper";
 import {erDevMiljo} from "../utils/ServiceHookTypes";
 import {EtikettLiten} from "../components/etikett/EtikettLiten";
+import {Heading, Label} from "@navikt/ds-react";
 
 interface Props {
     utbetalinger: UtbetalingSakType[];
@@ -37,7 +37,7 @@ const UtbetalingerPanel: React.FC<Props> = ({utbetalinger, lasterData}) => {
         <div className="utbetalinger_detaljer">
             {(!utbetalinger || utbetalinger.length === 0) && (
                 <div className="utbetaling__header">
-                    <Element>Vi finner ingen registrerte utbetalinger for perioden.</Element>
+                    <Label>Vi finner ingen registrerte utbetalinger for perioden.</Label>
                 </div>
             )}
             {utbetalinger &&
@@ -45,12 +45,18 @@ const UtbetalingerPanel: React.FC<Props> = ({utbetalinger, lasterData}) => {
                     return (
                         <span key={"utbetaling_" + index}>
                             {index > 0 && utbetalinger[index - 1].ar !== utbetalingSak.ar && (
-                                <Undertittel className="blokk-xs">{utbetalingSak.ar}</Undertittel>
+                                <Heading level="2" size="medium" className="blokk-xs">
+                                    {utbetalingSak.ar}
+                                </Heading>
                             )}
                             <div className="utbetalinger_detaljer_panel" key={"utbetaling_" + index}>
                                 <div className="utbetaling__header bunnSeparator">
-                                    <Undertittel>{utbetalingSak.maned + " " + utbetalingSak.ar}</Undertittel>
-                                    <Undertittel>{formatCurrency(sumUtbetalinger(utbetalingSak))} kr</Undertittel>
+                                    <Heading level="2" size="medium">
+                                        {utbetalingSak.maned + " " + utbetalingSak.ar}
+                                    </Heading>
+                                    <Heading level="2" size="medium">
+                                        {formatCurrency(sumUtbetalinger(utbetalingSak))} kr
+                                    </Heading>
                                 </div>
                                 {utbetalingSak.utbetalinger.map((utbetalingMaaned: UtbetalingMaaned, index: number) => {
                                     const annenMottaker: boolean = utbetalingMaaned.annenMottaker;
@@ -61,10 +67,10 @@ const UtbetalingerPanel: React.FC<Props> = ({utbetalinger, lasterData}) => {
                                             className={!erSisteUtbetaling ? "bunnSeparator tynnere" : ""}
                                         >
                                             <div className="utbetaling__header">
-                                                <Element>
+                                                <Label>
                                                     {utbetalingMaaned.tittel ? utbetalingMaaned.tittel : "Utbetaling"}{" "}
-                                                </Element>
-                                                <Element>{formatCurrency(utbetalingMaaned.belop)} kr</Element>
+                                                </Label>
+                                                <Label>{formatCurrency(utbetalingMaaned.belop)} kr</Label>
                                             </div>
                                             <UtbetalingEkspanderbart
                                                 tittel={"Utbetalt " + formatDato(utbetalingMaaned.utbetalingsdato)}
@@ -73,31 +79,31 @@ const UtbetalingerPanel: React.FC<Props> = ({utbetalinger, lasterData}) => {
                                                 <div className="mottaker__wrapper">
                                                     <EtikettLiten>Mottaker</EtikettLiten>
                                                     {annenMottaker ? (
-                                                        <Element style={{textTransform: "capitalize"}}>
+                                                        <Label style={{textTransform: "capitalize"}}>
                                                             {utbetalingMaaned.mottaker}
                                                             {utbetalingMaaned.utbetalingsmetode && (
                                                                 <span style={{textTransform: "lowercase"}}>
                                                                     &nbsp;({utbetalingMaaned.utbetalingsmetode})&nbsp;
                                                                 </span>
                                                             )}
-                                                        </Element>
+                                                        </Label>
                                                     ) : (
-                                                        <Element>
+                                                        <Label>
                                                             Til deg (
                                                             {utbetalingMaaned.utbetalingsmetode && (
                                                                 <>{utbetalingMaaned.utbetalingsmetode} </>
                                                             )}
                                                             {utbetalingMaaned.kontonummer})
-                                                        </Element>
+                                                        </Label>
                                                     )}
                                                 </div>
                                                 {utbetalingMaaned.fom && utbetalingMaaned.tom && (
                                                     <>
                                                         <EtikettLiten>Periode</EtikettLiten>
-                                                        <Element className="blokk-xs">
+                                                        <Label className="blokk-xs">
                                                             {formatDato(utbetalingMaaned.fom)} -
                                                             {formatDato(utbetalingMaaned.tom)}
-                                                        </Element>
+                                                        </Label>
                                                     </>
                                                 )}
                                                 <EtikettLiten className="soknad__header">Søknaden din</EtikettLiten>

--- a/src/utbetalinger/utbetalinger.less
+++ b/src/utbetalinger/utbetalinger.less
@@ -25,13 +25,8 @@
     display: flex;
     flex-direction: column;
 
-    h1 {
-        margin-bottom: 2rem;
-    }
-
     .utbetalinger__overskrift {
         text-align: center;
-        margin-bottom: 1rem;
     }
 }
 


### PR DESCRIPTION
Byttet ut typografielementer fra `nav-frontend-typografi` med tilsvarende fra `ds-react`.

Typografi fra ds-react øker default fontstørrelse fra 16px til 18px. Blir derfor et par mindre justeringer på noen komponenter. ds-react har også støtte for å legge på margin direkte på typografielementene, så fjerner en del manuell styling relatert til dette.