### PR TITLE
Toggler infoboksene Du har ingen oppgaver og Du kan ha vilkår

### DIFF
--- a/src/components/oppgaver/IngenOppgaverPanel.tsx
+++ b/src/components/oppgaver/IngenOppgaverPanel.tsx
@@ -10,7 +10,7 @@ import {
     SaksStatusState,
     Vilkar,
 } from "../../redux/innsynsdata/innsynsdataReducer";
-import {getSkalViseVilkarView} from "../vilkar/VilkarUtils";
+import {harSakMedInnvilgetEllerDelvisInnvilgetSak} from "../vilkar/VilkarUtils";
 import {BodyShort, Label, Panel} from "@navikt/ds-react";
 import styled from "styled-components";
 
@@ -35,12 +35,9 @@ const IngenOppgaverPanel: React.FC<Props> = ({dokumentasjonkrav, vilkar, dokumen
     };
 
     const skalViseIngenOppgaverPanel = () => {
-        return !(
-            getSkalViseVilkarView(innsynSaksStatusListe) ||
-            finnesOppgaver(dokumentasjonEtterspurt) ||
-            finnesOppgaver(dokumentasjonkrav) ||
-            finnesOppgaver(vilkar)
-        );
+        const harOppgaver =
+            finnesOppgaver(dokumentasjonEtterspurt) || finnesOppgaver(dokumentasjonkrav) || finnesOppgaver(vilkar);
+        return harSakMedInnvilgetEllerDelvisInnvilgetSak(innsynSaksStatusListe) && !harOppgaver;
     };
 
     if (skalViseIngenOppgaverPanel() && !leserData) {

--- a/src/components/vilkar/OppgaveInformasjon.tsx
+++ b/src/components/vilkar/OppgaveInformasjon.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {getSkalViseVilkarView} from "./VilkarUtils";
+import {harSakMedInnvilgetEllerDelvisInnvilgetSak} from "./VilkarUtils";
 import {useSelector} from "react-redux";
 import {InnsynAppState} from "../../redux/reduxTypes";
 import {DokumentasjonKrav, SaksStatusState, Vilkar} from "../../redux/innsynsdata/innsynsdataReducer";
@@ -20,9 +20,9 @@ const OppgaveInformasjon: React.FC<Props> = ({dokumentasjonkrav, vilkar}) => {
         (state: InnsynAppState) => state.innsynsdata.saksStatus
     );
 
-    const skalViseVilkarView = getSkalViseVilkarView(innsynSaksStatusListe);
+    const harSakInnvilgetEllerDelvisInnvilget = harSakMedInnvilgetEllerDelvisInnvilgetSak(innsynSaksStatusListe);
 
-    if (skalViseVilkarView && !vilkar && !dokumentasjonkrav) {
+    if (!harSakInnvilgetEllerDelvisInnvilget && !vilkar && !dokumentasjonkrav) {
         return (
             <EkspanderbartIkonPanel
                 tittel={<FormattedMessage id={"oppgaver.vilkar.tittel"} />}

--- a/src/components/vilkar/Vilkar.test.ts
+++ b/src/components/vilkar/Vilkar.test.ts
@@ -1,5 +1,5 @@
 import {SaksStatusState, SaksStatus} from "../../redux/innsynsdata/innsynsdataReducer";
-import {getSkalViseVilkarView} from "./VilkarUtils";
+import {harSakMedInnvilgetEllerDelvisInnvilgetSak} from "./VilkarUtils";
 
 const saksStatus1: SaksStatusState = {
     tittel: "Saksstatus 1",
@@ -31,6 +31,6 @@ const listSaksStatusState_skal_gi_false: SaksStatusState[] = [saksStatus1, saksS
 const listSaksStatusState_skal_gi_true: SaksStatusState[] = [saksStatus1, saksStatus2, saksStatus3, saksStatus4];
 
 it("viser kun vedtak info panel når minimum en sak har delvis innvilget eller innvilget som gjeldende vedtak.", () => {
-    expect(getSkalViseVilkarView(listSaksStatusState_skal_gi_false)).toEqual(false);
-    expect(getSkalViseVilkarView(listSaksStatusState_skal_gi_true)).toEqual(true);
+    expect(harSakMedInnvilgetEllerDelvisInnvilgetSak(listSaksStatusState_skal_gi_false)).toEqual(false);
+    expect(harSakMedInnvilgetEllerDelvisInnvilgetSak(listSaksStatusState_skal_gi_true)).toEqual(true);
 });

--- a/src/components/vilkar/VilkarUtils.ts
+++ b/src/components/vilkar/VilkarUtils.ts
@@ -1,6 +1,8 @@
 import {SaksStatusState} from "../../redux/innsynsdata/innsynsdataReducer";
 
-export const getSkalViseVilkarView = (innsynSaksStatusStateListe: SaksStatusState[] | undefined): boolean => {
+export const harSakMedInnvilgetEllerDelvisInnvilgetSak = (
+    innsynSaksStatusStateListe: SaksStatusState[] | undefined
+): boolean => {
     return (
         innsynSaksStatusStateListe !== undefined &&
         Array.isArray(innsynSaksStatusStateListe) &&


### PR DESCRIPTION
Viser "Du har ingen oppgaver" hvis det ikke finnes oppgaver og sakkstatus er `AVVIST`/`AVSLATT`.
Viser "Du kan ha vilkår" hvis det ikke finnes oppgaver og sakkstatus er `INNVILGET`/`DELVIS_INNVILGET`.

Lagde et langt navn på metoden for å hente saksstatus-parameteret fra backend som forhåpentligvis beskriver bruken bedre, siden jeg alltid ble forvirra av forrige navn.