### PR TITLE
Logger image-tag ved oppstart

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,9 @@ const decoratorParams = {
     logoutUrl: process.env.INNSYN_API_SINGLE_LOGOUT_URL || undefined,
 };
 
-console.log("starter fra docker-image", process.env.IMAGE);
+const dockerImage = process.env.IMAGE || process.env.NAIS_APP_IMAGE;
+
+console.log("starter fra docker image: ", dockerImage);
 
 const app = express(); // create express app
 app.disable("x-powered-by");

--- a/server.js
+++ b/server.js
@@ -9,8 +9,10 @@ const decoratorParams = {
     chatbot: false,
     shareScreen: false,
     utilsBackground: "white",
-    logoutUrl: process.env.INNSYN_API_SINGLE_LOGOUT_URL || undefined
+    logoutUrl: process.env.INNSYN_API_SINGLE_LOGOUT_URL || undefined,
 };
+
+console.log("starter fra docker-image", process.env.NAIS_APP_IMAGE);
 
 const app = express(); // create express app
 app.disable("x-powered-by");

--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ const decoratorParams = {
 
 const dockerImage = process.env.IMAGE || process.env.NAIS_APP_IMAGE;
 
-console.log("starter fra docker image: ", dockerImage);
+console.log("starter innsyn fra docker image: ", dockerImage);
 
 const app = express(); // create express app
 app.disable("x-powered-by");

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const decoratorParams = {
     logoutUrl: process.env.INNSYN_API_SINGLE_LOGOUT_URL || undefined,
 };
 
-console.log("starter fra docker-image", process.env.NAIS_APP_IMAGE);
+console.log("starter fra docker-image", process.env.IMAGE);
 
 const app = express(); // create express app
 app.disable("x-powered-by");


### PR DESCRIPTION
for å kunne få noe oversikt over deploy på VM-ene.

I `sosialhjelp-innsyn.service` må `ExecStart` utvides med `-e IMAGE=${IMAGE}` også (gjort)