### PR TITLE
Oppdaterer typescript fra 4.9.5 til 5.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,17 +48,17 @@
                 "@types/react-dom": "^18.2.7",
                 "@types/uuid": "^9.0.2",
                 "eslint": "8.46.0",
-                "eslint-config-next": "13.4.12",
+                "eslint-config-next": "^13.5.1",
                 "husky": "^8.0.3",
                 "jest": "^29.6.2",
                 "jest-environment-jsdom": "^29.6.2",
                 "lint-staged": "^13.2.3",
-                "msw": "^1.2.3",
+                "msw": "^1.3.2",
                 "next-router-mock": "^0.9.7",
                 "orval": "^6.17.0",
                 "pino-pretty": "^10.2.0",
                 "prettier": "^3.0.0",
-                "typescript": "^4.9.5"
+                "typescript": "^5.2.2"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -3169,16 +3169,16 @@
             }
         },
         "node_modules/@mswjs/interceptors": {
-            "version": "0.17.9",
-            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.9.tgz",
-            "integrity": "sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==",
+            "version": "0.17.10",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+            "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
             "dev": true,
             "dependencies": {
                 "@open-draft/until": "^1.0.3",
                 "@types/debug": "^4.1.7",
                 "@xmldom/xmldom": "^0.8.3",
                 "debug": "^4.3.3",
-                "headers-polyfill": "^3.1.0",
+                "headers-polyfill": "3.2.5",
                 "outvariant": "^1.2.1",
                 "strict-event-emitter": "^0.2.4",
                 "web-encoding": "^1.1.5"
@@ -3283,9 +3283,9 @@
             "integrity": "sha512-CIMWiOTyflFn/GFx33iYXkgLSQsMQZV4jB91qaj/TfxGaGOXxn8C1j72TaUSPIyN7ziS/AYG46kGmnvuk1oOpg=="
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "13.4.12",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.12.tgz",
-            "integrity": "sha512-6rhK9CdxEgj/j1qvXIyLTWEaeFv7zOK8yJMulz3Owel0uek0U9MJCGzmKgYxM3aAUBo3gKeywCZKyQnJKto60A==",
+            "version": "13.5.1",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.1.tgz",
+            "integrity": "sha512-LBlI3iQvlzRE7Y6AfIyHKuM4T6REGmFgweN2tBqEUVEfgxERBLOutV2xckXEp3Y3VbfJBBXKZNfDzs20gHimSg==",
             "dev": true,
             "dependencies": {
                 "glob": "7.1.7"
@@ -5399,9 +5399,9 @@
             "dev": true
         },
         "node_modules/@types/debug": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-            "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+            "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
             "dev": true,
             "dependencies": {
                 "@types/ms": "*"
@@ -5541,9 +5541,9 @@
             "dev": true
         },
         "node_modules/@types/ms": {
-            "version": "0.7.31",
-            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+            "version": "0.7.32",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
+            "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -8243,20 +8243,20 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "13.4.12",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.12.tgz",
-            "integrity": "sha512-ZF0r5vxKaVazyZH/37Au/XItiG7qUOBw+HaH3PeyXltIMwXorsn6bdrl0Nn9N5v5v9spc+6GM2ryjugbjF6X2g==",
+            "version": "13.5.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.5.1.tgz",
+            "integrity": "sha512-+8xIIWtD+iFwHfXgmXRGn05BuNIu/RAGcz6kI4wsJTPrE/1WtWKv2o0l+GbQ6wRaC+cbBV8+QnFAOf18aJiWrg==",
             "dev": true,
             "dependencies": {
-                "@next/eslint-plugin-next": "13.4.12",
-                "@rushstack/eslint-patch": "^1.1.3",
-                "@typescript-eslint/parser": "^5.42.0",
+                "@next/eslint-plugin-next": "13.5.1",
+                "@rushstack/eslint-patch": "^1.3.3",
+                "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
-                "eslint-plugin-import": "^2.26.0",
-                "eslint-plugin-jsx-a11y": "^6.5.1",
-                "eslint-plugin-react": "^7.31.7",
-                "eslint-plugin-react-hooks": "5.0.0-canary-7118f5dd7-20230705"
+                "eslint-plugin-import": "^2.28.1",
+                "eslint-plugin-jsx-a11y": "^6.7.1",
+                "eslint-plugin-react": "^7.33.2",
+                "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
             },
             "peerDependencies": {
                 "eslint": "^7.23.0 || ^8.0.0",
@@ -9424,9 +9424,9 @@
             "dev": true
         },
         "node_modules/graphql": {
-            "version": "16.8.0",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-            "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+            "version": "16.8.1",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+            "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -9510,9 +9510,9 @@
             }
         },
         "node_modules/headers-polyfill": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.0.tgz",
-            "integrity": "sha512-NsYkbrWFQyoPBrbX5riycJ3D4aaB/3fpx1nYgDi3JTTnoeFET3BN0rq2nOB3VUmvpQrYpbKL8zRJo1Jsmmt7nA==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
+            "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
             "dev": true
         },
         "node_modules/help-me": {
@@ -13735,22 +13735,22 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/msw": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/msw/-/msw-1.2.5.tgz",
-            "integrity": "sha512-Y3MwnAHX3d162eSWrEUeRdCv3+8hmgz/+Wh7OUkE6VB55+YTswxrep3yU3evZnKWHJGAM63G1s+olAgzIFdYtQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
+            "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "@mswjs/cookies": "^0.2.2",
-                "@mswjs/interceptors": "^0.17.5",
+                "@mswjs/interceptors": "^0.17.10",
                 "@open-draft/until": "^1.0.3",
                 "@types/cookie": "^0.4.1",
                 "@types/js-levenshtein": "^1.1.1",
                 "chalk": "^4.1.1",
                 "chokidar": "^3.4.2",
                 "cookie": "^0.4.2",
-                "graphql": "^15.0.0 || ^16.0.0",
-                "headers-polyfill": "^3.1.2",
+                "graphql": "^16.8.1",
+                "headers-polyfill": "3.2.5",
                 "inquirer": "^8.2.0",
                 "is-node-process": "^1.2.0",
                 "js-levenshtein": "^1.1.6",
@@ -13772,7 +13772,7 @@
                 "url": "https://opencollective.com/mswjs"
             },
             "peerDependencies": {
-                "typescript": ">= 4.4.x <= 5.1.x"
+                "typescript": ">= 4.4.x <= 5.2.x"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -17238,16 +17238,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/unbox-primitive": {
@@ -20144,16 +20144,16 @@
             }
         },
         "@mswjs/interceptors": {
-            "version": "0.17.9",
-            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.9.tgz",
-            "integrity": "sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==",
+            "version": "0.17.10",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+            "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
             "dev": true,
             "requires": {
                 "@open-draft/until": "^1.0.3",
                 "@types/debug": "^4.1.7",
                 "@xmldom/xmldom": "^0.8.3",
                 "debug": "^4.3.3",
-                "headers-polyfill": "^3.1.0",
+                "headers-polyfill": "3.2.5",
                 "outvariant": "^1.2.1",
                 "strict-event-emitter": "^0.2.4",
                 "web-encoding": "^1.1.5"
@@ -20230,9 +20230,9 @@
             "integrity": "sha512-CIMWiOTyflFn/GFx33iYXkgLSQsMQZV4jB91qaj/TfxGaGOXxn8C1j72TaUSPIyN7ziS/AYG46kGmnvuk1oOpg=="
         },
         "@next/eslint-plugin-next": {
-            "version": "13.4.12",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.12.tgz",
-            "integrity": "sha512-6rhK9CdxEgj/j1qvXIyLTWEaeFv7zOK8yJMulz3Owel0uek0U9MJCGzmKgYxM3aAUBo3gKeywCZKyQnJKto60A==",
+            "version": "13.5.1",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.1.tgz",
+            "integrity": "sha512-LBlI3iQvlzRE7Y6AfIyHKuM4T6REGmFgweN2tBqEUVEfgxERBLOutV2xckXEp3Y3VbfJBBXKZNfDzs20gHimSg==",
             "dev": true,
             "requires": {
                 "glob": "7.1.7"
@@ -21840,9 +21840,9 @@
             "dev": true
         },
         "@types/debug": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-            "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+            "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
             "dev": true,
             "requires": {
                 "@types/ms": "*"
@@ -21975,9 +21975,9 @@
             "dev": true
         },
         "@types/ms": {
-            "version": "0.7.31",
-            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+            "version": "0.7.32",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
+            "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g==",
             "dev": true
         },
         "@types/node": {
@@ -23979,20 +23979,20 @@
             }
         },
         "eslint-config-next": {
-            "version": "13.4.12",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.4.12.tgz",
-            "integrity": "sha512-ZF0r5vxKaVazyZH/37Au/XItiG7qUOBw+HaH3PeyXltIMwXorsn6bdrl0Nn9N5v5v9spc+6GM2ryjugbjF6X2g==",
+            "version": "13.5.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.5.1.tgz",
+            "integrity": "sha512-+8xIIWtD+iFwHfXgmXRGn05BuNIu/RAGcz6kI4wsJTPrE/1WtWKv2o0l+GbQ6wRaC+cbBV8+QnFAOf18aJiWrg==",
             "dev": true,
             "requires": {
-                "@next/eslint-plugin-next": "13.4.12",
-                "@rushstack/eslint-patch": "^1.1.3",
-                "@typescript-eslint/parser": "^5.42.0",
+                "@next/eslint-plugin-next": "13.5.1",
+                "@rushstack/eslint-patch": "^1.3.3",
+                "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
-                "eslint-plugin-import": "^2.26.0",
-                "eslint-plugin-jsx-a11y": "^6.5.1",
-                "eslint-plugin-react": "^7.31.7",
-                "eslint-plugin-react-hooks": "5.0.0-canary-7118f5dd7-20230705"
+                "eslint-plugin-import": "^2.28.1",
+                "eslint-plugin-jsx-a11y": "^6.7.1",
+                "eslint-plugin-react": "^7.33.2",
+                "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
             }
         },
         "eslint-import-resolver-node": {
@@ -24803,9 +24803,9 @@
             "dev": true
         },
         "graphql": {
-            "version": "16.8.0",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-            "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+            "version": "16.8.1",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+            "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
             "dev": true
         },
         "has": {
@@ -24856,9 +24856,9 @@
             }
         },
         "headers-polyfill": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.0.tgz",
-            "integrity": "sha512-NsYkbrWFQyoPBrbX5riycJ3D4aaB/3fpx1nYgDi3JTTnoeFET3BN0rq2nOB3VUmvpQrYpbKL8zRJo1Jsmmt7nA==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
+            "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
             "dev": true
         },
         "help-me": {
@@ -27977,21 +27977,21 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "msw": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/msw/-/msw-1.2.5.tgz",
-            "integrity": "sha512-Y3MwnAHX3d162eSWrEUeRdCv3+8hmgz/+Wh7OUkE6VB55+YTswxrep3yU3evZnKWHJGAM63G1s+olAgzIFdYtQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
+            "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
             "dev": true,
             "requires": {
                 "@mswjs/cookies": "^0.2.2",
-                "@mswjs/interceptors": "^0.17.5",
+                "@mswjs/interceptors": "^0.17.10",
                 "@open-draft/until": "^1.0.3",
                 "@types/cookie": "^0.4.1",
                 "@types/js-levenshtein": "^1.1.1",
                 "chalk": "^4.1.1",
                 "chokidar": "^3.4.2",
                 "cookie": "^0.4.2",
-                "graphql": "^15.0.0 || ^16.0.0",
-                "headers-polyfill": "^3.1.2",
+                "graphql": "^16.8.1",
+                "headers-polyfill": "3.2.5",
                 "inquirer": "^8.2.0",
                 "is-node-process": "^1.2.0",
                 "js-levenshtein": "^1.1.6",
@@ -30541,9 +30541,9 @@
             }
         },
         "typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true
         },
         "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -70,17 +70,17 @@
         "@types/react-dom": "^18.2.7",
         "@types/uuid": "^9.0.2",
         "eslint": "8.46.0",
-        "eslint-config-next": "13.4.12",
+        "eslint-config-next": "^13.5.1",
         "husky": "^8.0.3",
         "jest": "^29.6.2",
         "jest-environment-jsdom": "^29.6.2",
         "lint-staged": "^13.2.3",
-        "msw": "^1.2.3",
+        "msw": "^1.3.2",
         "next-router-mock": "^0.9.7",
         "orval": "^6.17.0",
         "pino-pretty": "^10.2.0",
         "prettier": "^3.0.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.2.2"
     },
     "lint-staged": {
         "*.{js,jsx,ts,tsx,css,md}": "prettier --write",

--- a/src/axios-instance.ts
+++ b/src/axios-instance.ts
@@ -31,7 +31,7 @@ export const axiosInstance = <T>(
         .catch(async (e) => {
             Object.assign(e, {navCallId: e.config?.headers["Nav-Call-Id"]});
 
-            if (!(e instanceof AxiosError<T>)) {
+            if (!e.isAxiosError) {
                 logger.warn(`non-axioserror error ${e} in axiosinstance`, e.navCallId);
             }
 

--- a/src/utils/vedleggUtils.ts
+++ b/src/utils/vedleggUtils.ts
@@ -6,9 +6,9 @@ export const maxCombinedFileSize = 150 * 1024 * 1024; // max bytes lov å laste 
 export const maxFileSize = 10 * 1024 * 1024; // max bytes per fil
 
 export const hentFileExtension = (filnavn: string) => {
-    var filetternavn = "ukjent";
+    let filetternavn = "ukjent";
     if (filnavn.length >= 5) {
-        var testSteng = filnavn.substr(filnavn.length - 5, 5);
+        let testSteng = filnavn.substr(filnavn.length - 5, 5);
         const punktumPosisjon = testSteng.indexOf(".");
         if (punktumPosisjon > -1) {
             filetternavn = testSteng.substr(punktumPosisjon + 1, 4 - punktumPosisjon);

--- a/src/utils/vedleggUtils.ts
+++ b/src/utils/vedleggUtils.ts
@@ -6,9 +6,9 @@ export const maxCombinedFileSize = 150 * 1024 * 1024; // max bytes lov å laste 
 export const maxFileSize = 10 * 1024 * 1024; // max bytes per fil
 
 export const hentFileExtension = (filnavn: string) => {
-    let filetternavn = "ukjent";
+    var filetternavn = "ukjent";
     if (filnavn.length >= 5) {
-        let testSteng = filnavn.substr(filnavn.length - 5, 5);
+        var testSteng = filnavn.substr(filnavn.length - 5, 5);
         const punktumPosisjon = testSteng.indexOf(".");
         if (punktumPosisjon > -1) {
             filetternavn = testSteng.substr(punktumPosisjon + 1, 4 - punktumPosisjon);


### PR DESCRIPTION
Det skjedde litt endringer i hvordan type `[brukes i 5.1](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-1.html#avoiding-unnecessary-type-instantiation)`, og derfor ble `(e instanceof AxiosError<T>)` endret til `e.isAxiosError`. Skal ha samme resultat.