### PR TITLE
Fjerner foreldet "React.FC"-syntaks

### DIFF
--- a/src/components/Infopanel/InfoPanel.tsx
+++ b/src/components/Infopanel/InfoPanel.tsx
@@ -36,7 +36,7 @@ type Props = {
     href: string;
 };
 
-const InfoPanel: React.FC<Props> = ({ children, tittel, href }) => {
+const InfoPanel = ({ children, tittel, href }: Props) => {
     return (
         <StyledLinkPanel href={href} border={false}>
             <LinkPanel.Title as="h3">{tittel}</LinkPanel.Title>

--- a/src/components/Tilgangskontrollside/Tilgangskontrollside.tsx
+++ b/src/components/Tilgangskontrollside/Tilgangskontrollside.tsx
@@ -43,7 +43,7 @@ const useDekoratorLogin = () =>
         },
     });
 
-const Tilgangskontrollside: React.FC<TilgangskontrollsideProps> = ({ children }) => {
+const Tilgangskontrollside = ({ children }: TilgangskontrollsideProps) => {
     const router = useRouter();
     const { t } = useTranslation();
     const { error, isPending, data: harTilgangData } = useHarTilgang();

--- a/src/components/arkfanePanel/ArkfanePanel.tsx
+++ b/src/components/arkfanePanel/ArkfanePanel.tsx
@@ -32,7 +32,7 @@ interface Props {
     vedleggChildren: React.ReactNode;
 }
 
-const ArkfanePanel: React.FC<Props> = (props) => {
+const ArkfanePanel = (props: Props) => {
     const fiksDigisosId = useFiksDigisosId();
     const { t } = useTranslation();
     const [valgtFane, setValgtFane] = React.useState<string>(ARKFANER.HISTORIKK);

--- a/src/components/driftsmelding/Driftsmelding.tsx
+++ b/src/components/driftsmelding/Driftsmelding.tsx
@@ -13,7 +13,7 @@ const StyledAlert = styled(Alert)`
     margin-bottom: 1rem;
 `;
 
-const DriftsmeldingAlertstripe: React.FC = () => {
+const DriftsmeldingAlertstripe = () => {
     const { kommune } = useKommune();
     const fiksDigisosId = useFiksDigisosId();
 

--- a/src/components/eksternLenke/EksternLenke.tsx
+++ b/src/components/eksternLenke/EksternLenke.tsx
@@ -6,7 +6,7 @@ interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     href: string;
 }
 
-const EksternLenke: React.FC<Props> = ({ children, href, onClick }) => {
+const EksternLenke = ({ children, href, onClick }: Props) => {
     const { t } = useTranslation();
     return (
         <Link href={href} target="_blank" onClick={onClick} rel="noopener noreferrer">

--- a/src/components/ellaBlunk/index.tsx
+++ b/src/components/ellaBlunk/index.tsx
@@ -4,7 +4,7 @@ interface EllaProps {
     size: string;
 }
 
-const EllaBlunk: React.FC<EllaProps> = (props: EllaProps) => {
+const EllaBlunk = (props: EllaProps) => {
     return (
         <svg
             aria-hidden="true"

--- a/src/components/filopplasting/AddFileButton.tsx
+++ b/src/components/filopplasting/AddFileButton.tsx
@@ -11,7 +11,7 @@ interface Props {
     title?: string;
 }
 
-const AddFileButton: React.FC<Props> = ({ onChange, id, resetStatus, hasError, disabled, title }) => {
+const AddFileButton = ({ onChange, id, resetStatus, hasError, disabled, title }: Props) => {
     const { t } = useTranslation();
 
     const onClick = (event?: React.MouseEvent<HTMLButtonElement>): void => {

--- a/src/components/forelopigSvar/ForelopigSvar.tsx
+++ b/src/components/forelopigSvar/ForelopigSvar.tsx
@@ -7,7 +7,7 @@ import { useHentForelopigSvarStatus } from "../../generated/forelopig-svar-contr
 import { useHentSoknadsStatus } from "../../generated/soknads-status-controller/soknads-status-controller";
 import useFiksDigisosId from "../../hooks/useFiksDigisosId";
 
-const ForelopigSvarAlertstripe: React.FC = () => {
+const ForelopigSvarAlertstripe = () => {
     const soknadId = useFiksDigisosId();
     const { t } = useTranslation();
 

--- a/src/components/historikk/Historikk.tsx
+++ b/src/components/historikk/Historikk.tsx
@@ -46,7 +46,7 @@ interface HistorikkListeProps {
     leserData: boolean;
 }
 
-const HistorikkListe: React.FC<HistorikkListeProps> = ({ hendelser, className, leserData }) => {
+const HistorikkListe = ({ hendelser, className, leserData }: HistorikkListeProps) => {
     const { t } = useTranslation();
     if (leserData) {
         return <Lastestriper linjer={3} />;
@@ -179,11 +179,11 @@ const HistorikkListe: React.FC<HistorikkListeProps> = ({ hendelser, className, l
     );
 };
 
-const KortHistorikk: React.FC<{ hendelser: HendelseResponse[]; leserData: boolean }> = ({ hendelser, leserData }) => {
+const KortHistorikk = ({ hendelser, leserData }: { hendelser: HendelseResponse[]; leserData: boolean }) => {
     return <HistorikkListe hendelser={hendelser} className="historikk" leserData={leserData} />;
 };
 
-const LangHistorikk: React.FC<{ hendelser: HendelseResponse[] }> = ({ hendelser }) => {
+const LangHistorikk = ({ hendelser }: { hendelser: HendelseResponse[] }) => {
     const [apen, setApen] = useState(false);
     const historikkListeClassname = apen ? "historikk_start" : "historikk_start_lukket";
     const { t } = useTranslation();
@@ -227,7 +227,7 @@ const StyledTextPlacement = styled.div`
     }
 `;
 
-const Historikk: React.FC<Props> = ({ fiksDigisosId }) => {
+const Historikk = ({ fiksDigisosId }: Props) => {
     const { data: hendelser, isLoading, isError } = useHentHendelser(fiksDigisosId);
     const { t } = useTranslation();
 

--- a/src/components/historikk/Historikk.tsx
+++ b/src/components/historikk/Historikk.tsx
@@ -124,7 +124,7 @@ const HistorikkListe: React.FC<HistorikkListeProps> = ({ hendelser, className, l
             return (
                 <BodyShort weight="semibold">
                     <Trans i18nKey={enumValue} t={t}>
-                        <span lang="no">{{ tekstArgument }}</span> er under behandling.
+                        <span lang="no">{tekstArgument}</span> er under behandling.
                     </Trans>
                 </BodyShort>
             );
@@ -142,7 +142,7 @@ const HistorikkListe: React.FC<HistorikkListeProps> = ({ hendelser, className, l
             return (
                 <BodyShort weight="semibold">
                     <Trans i18nKey={enumValue} t={t}>
-                        <span lang="no">{{ tekstArgument }}</span>
+                        <span lang="no">{tekstArgument}</span>
                     </Trans>
                 </BodyShort>
             );

--- a/src/components/ikoner/AapnetBrev.tsx
+++ b/src/components/ikoner/AapnetBrev.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const AapnetBrev: React.FC = () => {
+const AapnetBrev = () => {
     return (
         <svg
             aria-hidden="true"

--- a/src/components/ikoner/Dokument.tsx
+++ b/src/components/ikoner/Dokument.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Dokument: React.FC = () => {
+const Dokument = () => {
     return (
         <svg
             aria-hidden="true"

--- a/src/components/ikoner/DokumentSendt.tsx
+++ b/src/components/ikoner/DokumentSendt.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const DokumentSendt: React.FC = () => {
+const DokumentSendt = () => {
     return (
         <svg
             aria-hidden="true"

--- a/src/components/ikoner/GodkjentMerke.tsx
+++ b/src/components/ikoner/GodkjentMerke.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const GodkjentMerke: React.FC = () => {
+const GodkjentMerke = () => {
     return (
         <svg
             aria-hidden="true"

--- a/src/components/ikoner/InfoIkon.tsx
+++ b/src/components/ikoner/InfoIkon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const InfoIkon: React.FC = () => {
+const InfoIkon = () => {
     return (
         <svg aria-labelledby="info-ikon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
             <title id="info-ikon">Informasjon</title>

--- a/src/components/ikoner/LukketBrev.tsx
+++ b/src/components/ikoner/LukketBrev.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const LukketBrev: React.FC = () => {
+const LukketBrev = () => {
     return (
         <svg
             aria-hidden="true"

--- a/src/components/ikoner/Timeglass.tsx
+++ b/src/components/ikoner/Timeglass.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Timeglass: React.FC = () => {
+const Timeglass = () => {
     return (
         <svg
             aria-hidden="true"

--- a/src/components/lastestriper/Lasterstriper.tsx
+++ b/src/components/lastestriper/Lasterstriper.tsx
@@ -38,7 +38,7 @@ const lastestriper = (linjer: number): React.ReactNode[] => {
     return divs;
 };
 
-const Lastestriper: React.FC<NavFrontendLastestriperProps> = ({ linjer = 3, style }) => (
+const Lastestriper = ({ linjer = 3, style }: NavFrontendLastestriperProps) => (
     <StyledLastestriper style={style} data-testid="lastestriper">
         {lastestriper(linjer)}
     </StyledLastestriper>

--- a/src/components/oppgaver/IngenOppgaverPanel.tsx
+++ b/src/components/oppgaver/IngenOppgaverPanel.tsx
@@ -17,7 +17,7 @@ interface Props {
     leserData: boolean;
 }
 
-const IngenOppgaverPanel: React.FC<Props> = ({ leserData }) => {
+const IngenOppgaverPanel = ({ leserData }: Props) => {
     const { t } = useTranslation();
     if (leserData) {
         return null;

--- a/src/components/oppgaver/vilkar/VilkarView.tsx
+++ b/src/components/oppgaver/vilkar/VilkarView.tsx
@@ -9,7 +9,7 @@ interface Props {
     vilkar: VilkarResponse[];
 }
 
-export const VilkarView: React.FC<Props> = ({ vilkar }) => {
+export const VilkarView = ({ vilkar }: Props) => {
     return (
         <ul className={styles.vilkar_liste}>
             {vilkar.map((element) => (

--- a/src/components/subheader/Subheader.tsx
+++ b/src/components/subheader/Subheader.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import styles from "./subheader.module.css";
 
-const Subheader: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className }) => {
+const Subheader = ({ children, className }: { children: React.ReactNode; className?: string }) => {
     return <div className={`${styles.informasjonstavle__subheader} ${className}`}>{children}</div>;
 };
 

--- a/src/components/vedlegg/VedleggModal.tsx
+++ b/src/components/vedlegg/VedleggModal.tsx
@@ -10,7 +10,7 @@ interface Props {
     onRequestClose: () => void;
 }
 
-const VedleggModal: React.FC<Props> = ({ file, synlig, onRequestClose }) => {
+const VedleggModal = ({ file, synlig, onRequestClose }: Props) => {
     if (!file) {
         return null;
     }

--- a/src/components/vedlegg/VedleggView.tsx
+++ b/src/components/vedlegg/VedleggView.tsx
@@ -160,7 +160,7 @@ const StyledTextPlacement = styled.div`
 
 const itemsPerPage = 10;
 
-const VedleggView: React.FC<Props> = ({ fiksDigisosId }) => {
+const VedleggView = ({ fiksDigisosId }: Props) => {
     const { t } = useTranslation();
     const isMobile = useIsMobile();
     const { data: vedlegg, isLoading, isError } = useHentVedlegg(fiksDigisosId);

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -16,7 +16,7 @@ const PageWrapper = styled(Panel)`
     }
 `;
 
-const SideIkkeFunnet: React.FC = () => {
+const SideIkkeFunnet = () => {
     const { t } = useTranslation();
     useUpdateBreadcrumbs(() => [{ title: "Feil: Fant ikke siden  ", url: "/" }]);
 

--- a/src/saksoversikt/SaksoversiktDineSaker.tsx
+++ b/src/saksoversikt/SaksoversiktDineSaker.tsx
@@ -46,7 +46,7 @@ const sammenlignSaksTidspunkt = (a: SaksListeResponse, b: SaksListeResponse) => 
     return 0;
 };
 
-const SaksoversiktDineSaker: React.FC<{ saker: SaksListeResponse[] }> = ({ saker }) => {
+const SaksoversiktDineSaker = ({ saker }: { saker: SaksListeResponse[] }) => {
     const { t } = useTranslation();
 
     // En kjappere måte å finne ut om vi skal vise utbetalinger... Desverre så støtter ikke alle fagsystemene utbetalinger ennå.

--- a/src/saksoversikt/SaksoversiktIngenSoknader.tsx
+++ b/src/saksoversikt/SaksoversiktIngenSoknader.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
     padding-top: 1rem;
 `;
 
-const SaksoversiktIngenSoknader: React.FC = () => {
+const SaksoversiktIngenSoknader = () => {
     const { t } = useTranslation();
     return (
         <Wrapper>

--- a/src/saksoversikt/banner/UserIcon.tsx
+++ b/src/saksoversikt/banner/UserIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const UserIcon: React.FC = () => {
+const UserIcon = () => {
     return (
         <svg
             aria-hidden="true"

--- a/src/saksoversikt/dineUtbetalinger/DineUtbetalingerPanel.tsx
+++ b/src/saksoversikt/dineUtbetalinger/DineUtbetalingerPanel.tsx
@@ -10,7 +10,7 @@ import styles from "./dineUtbetalingerPanel.module.css";
 
 logAmplitudeEvent("Dine utbetalinger panel vises");
 
-const DineUtbetalingerPanel: React.FC = () => {
+const DineUtbetalingerPanel = () => {
     const { t } = useTranslation("utbetalinger");
     return (
         <Link href="/utbetaling" legacyBehavior passHref>

--- a/src/saksoversikt/sakpanel/SakPanel.tsx
+++ b/src/saksoversikt/sakpanel/SakPanel.tsx
@@ -46,7 +46,7 @@ interface Props {
     isBroken: boolean;
 }
 
-const SakPanel: React.FC<Props> = ({ fiksDigisosId, tittel, oppdatert, url, kilde, isBroken }) => {
+const SakPanel = ({ fiksDigisosId, tittel, oppdatert, url, kilde, isBroken }: Props) => {
     const { data: saksdetaljer, isLoading } = useHentSaksDetaljer(
         { id: fiksDigisosId! },
         { query: { enabled: kilde === "innsyn-api" && !!fiksDigisosId } }

--- a/src/utbetalinger/UtbetalingsoversiktIngenInnsyn.tsx
+++ b/src/utbetalinger/UtbetalingsoversiktIngenInnsyn.tsx
@@ -19,7 +19,7 @@ const Wrapper = styled.div`
     padding-bottom: 50px;
 `;
 
-const UtbetalingsoversiktIngenInnsyn: React.FC = () => {
+const UtbetalingsoversiktIngenInnsyn = () => {
     const { t } = useTranslation();
 
     return (

--- a/src/utbetalinger/UtbetalingsoversiktIngenSoknader.tsx
+++ b/src/utbetalinger/UtbetalingsoversiktIngenSoknader.tsx
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
     max-width: 50rem;
 `;
 
-const UtbetalingsoversiktIngenSoknader: React.FC = () => {
+const UtbetalingsoversiktIngenSoknader = () => {
     const { t } = useTranslation();
     return (
         <Wrapper>


### PR DESCRIPTION
React.FC considered deprecated, jamfør:
https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components/

Bruker derfor en codemod til å fjerne dem alle:
https://codemod.com/registry/react-replace-react-fc-typescript

Første commit var en best-guess på hvordan fikse en syntaksfeil