### PR TITLE
Fjerner trailingSlash i next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -50,7 +50,6 @@ const nextConfig = {
         ignoreDuringBuilds: true,
         dirs: ["src"],
     },
-    trailingSlash: true,
     productionBrowserSourceMaps: true,
 };
 


### PR DESCRIPTION
vi tror og håper dette ikke er nødvendig nå som login-api er pensjonert

Testet i preprod, funker der