### PR TITLE
bugfix: infinite redirect loop om tilgangskontroll feiler

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -64,6 +64,9 @@ export async function middleware(request: NextRequest) {
                 return NextResponse.redirect(json.loginUrl + queryDivider + redirectUrl);
             }
         } catch (e) {
+            logger.warn(pathname);
+            // ikke logg eller redirect dersom feilen oppstod i forsøk på å rendre 500-siden
+            if (pathname === "/500") return;
             logger.warn("Feil i middleware fetch, sender bruker til 500", e);
             return NextResponse.redirect(process.env.NEXT_PUBLIC_INNSYN_ORIGIN + "/sosialhjelp/innsyn/500");
         }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -64,7 +64,6 @@ export async function middleware(request: NextRequest) {
                 return NextResponse.redirect(json.loginUrl + queryDivider + redirectUrl);
             }
         } catch (e) {
-            logger.warn(pathname);
             // ikke logg eller redirect dersom feilen oppstod i forsøk på å rendre 500-siden
             if (pathname === "/500") return;
             logger.warn("Feil i middleware fetch, sender bruker til 500", e);


### PR DESCRIPTION
Dersom tilgang-kallet feiler, sendes brukeren til 500-siden, men den prøver jo også tilgangskallet.