### PR TITLE
Refaktor av CSP directives

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,25 +22,17 @@ const appDirectives = {
     "connect-src": [SELF, ...(isLocal ? [innsynApiLocalhost] : [])],
 };
 
+const buildInnsynCspHeader = async () => ({
+    key: "Content-Security-Policy",
+    value: await buildCspHeader(appDirectives, { env: isProd ? "prod" : "dev" }),
+});
+
 /**
  * @type {import('next').NextConfig}
  */
 
 const nextConfig = {
-    async headers() {
-        const cspValue = await buildCspHeader(appDirectives, { env: isProd ? "prod" : "dev" });
-        return [
-            {
-                source: "/:path*",
-                headers: [
-                    {
-                        key: "Content-Security-Policy",
-                        value: cspValue,
-                    },
-                ],
-            },
-        ];
-    },
+    headers: async () => [{ source: "/:path*", headers: [await buildInnsynCspHeader()] }],
     output: "standalone",
     assetPrefix: process.env.NODE_ENV === "production" ? process.env.NEXT_PUBLIC_ASSET_PREFIX : undefined,
     reactStrictMode: true,

--- a/next.config.js
+++ b/next.config.js
@@ -5,27 +5,14 @@ const [SELF, UNSAFE_INLINE, UNSAFE_EVAL] = ["'self'", "'unsafe-inline'", "'unsaf
 
 const appDirectives = {
     "default-src": [SELF],
-    "script-src": [
-        SELF,
-        UNSAFE_EVAL,
-        "https://uxsignals-frontend.uxsignals.app.iterate.no",
-        "https://widget.uxsignals.com",
-    ],
+    "script-src": [SELF, UNSAFE_EVAL, "https://uxsignals-frontend.uxsignals.app.iterate.no"],
     "script-src-elem": [SELF, "https://uxsignals-frontend.uxsignals.app.iterate.no"],
     "style-src": [SELF, UNSAFE_INLINE],
-    "img-src": [
-        SELF,
-        "data:",
-        "blob:",
-        "https://uxsignals-frontend.uxsignals.app.iterate.no",
-        "https://widget.uxsignals.com",
-    ],
-    "font-src": [SELF, "https://cdn.nav.no"],
+    "img-src": [SELF, "data:", "blob:", "https://uxsignals-frontend.uxsignals.app.iterate.no"],
+    "font-src": [SELF],
     "worker-src": [SELF],
     "connect-src": [
         SELF,
-        "https://*.nav.no",
-        "https://*.uxsignals.com",
         ...(process.env.NEXT_PUBLIC_RUNTIME_ENVIRONMENT === "local" ? ["http://localhost:8989"] : []),
     ],
 };

--- a/next.config.js
+++ b/next.config.js
@@ -1,27 +1,29 @@
 const { buildCspHeader } = require("@navikt/nav-dekoratoren-moduler/ssr");
 const { i18n } = require("./next-i18next.config");
 
+const [SELF, UNSAFE_INLINE, UNSAFE_EVAL] = ["'self'", "'unsafe-inline'", "'unsafe-eval'"];
+
 const appDirectives = {
-    "default-src": ["'self'"],
+    "default-src": [SELF],
     "script-src": [
-        "'self'",
-        "'unsafe-eval'",
+        SELF,
+        UNSAFE_EVAL,
         "https://uxsignals-frontend.uxsignals.app.iterate.no",
         "https://widget.uxsignals.com",
     ],
-    "script-src-elem": ["'self'", "https://uxsignals-frontend.uxsignals.app.iterate.no"],
-    "style-src": ["'self'", "'unsafe-inline'"],
+    "script-src-elem": [SELF, "https://uxsignals-frontend.uxsignals.app.iterate.no"],
+    "style-src": [SELF, UNSAFE_INLINE],
     "img-src": [
-        "'self'",
+        SELF,
         "data:",
         "blob:",
         "https://uxsignals-frontend.uxsignals.app.iterate.no",
         "https://widget.uxsignals.com",
     ],
-    "font-src": ["'self'", "https://cdn.nav.no"],
-    "worker-src": ["'self'"],
+    "font-src": [SELF, "https://cdn.nav.no"],
+    "worker-src": [SELF],
     "connect-src": [
-        "'self'",
+        SELF,
         "https://*.nav.no",
         "https://*.uxsignals.com",
         ...(process.env.NEXT_PUBLIC_RUNTIME_ENVIRONMENT === "local" ? ["http://localhost:8989"] : []),

--- a/next.config.js
+++ b/next.config.js
@@ -19,20 +19,25 @@ const appDirectives = {
     "img-src": [SELF, DATA, BLOB, uxsignalsScriptSrc],
     "font-src": [SELF],
     "worker-src": [SELF],
-    "connect-src": [SELF, ...(isLocal ? [innsynApiLocalhost] : [])],
+    "connect-src": isLocal ? [SELF, innsynApiLocalhost] : [SELF],
 };
-
-const buildInnsynCspHeader = async () => ({
-    key: "Content-Security-Policy",
-    value: await buildCspHeader(appDirectives, { env: isProd ? "prod" : "dev" }),
-});
 
 /**
  * @type {import('next').NextConfig}
  */
 
 const nextConfig = {
-    headers: async () => [{ source: "/:path*", headers: [await buildInnsynCspHeader()] }],
+    headers: async () => [
+        {
+            source: "/:path*",
+            headers: [
+                {
+                    key: "Content-Security-Policy",
+                    value: await buildCspHeader(appDirectives, { env: isProd ? "prod" : "dev" }),
+                },
+            ],
+        },
+    ],
     output: "standalone",
     assetPrefix: process.env.NODE_ENV === "production" ? process.env.NEXT_PUBLIC_ASSET_PREFIX : undefined,
     reactStrictMode: true,


### PR DESCRIPTION
Ville bare gjøre det litt mer leselig :)

Jeg sjekket [hvordan csp blir gjort i nav-dekoratoren](https://github.com/navikt/nav-dekoratoren/blob/main/packages/server/src/content-security-policy.ts), og fant ut at direktivene vi gir, flettes med direktivene dekoratoren gir, som inkluderer uxsignals og NAV CDN. Dermed var det en del som var dublert som vi kan fjerne fra vår side.

Jeg vet ingenting om `https://uxsignals-frontend.uxsignals.app.iterate.no`, men den var ikke i nav-dekoratorens liste så jeg beholder den.

Det er verdt å merke seg at én policy på connect-src blir innsnevret fra *.uxsignals.com til api.uxsignals.com fordi dette er nav-dekoratoren sin preset, siden det også er [verdien oppgitt i uxsignals' egen dok](https://app.uxsignals.com/docs#CSP), antar jeg connect-src bare var for vid i utgangspunktet.