### PR TITLE
Legger til bekreftelse på at fil er slettet

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -219,7 +219,6 @@
         "valgteFiler": "Selected files ({antall_filer})",
         "filerTilOpplasting": "Files for upload",
         "antallFiler": "{count, plural, one {# file ready for upload} other {# files ready for upload}}",
-        "antallFilerValgt": "{count, plural, zero {No files remaining} one {# file remaining} other {# files remaining}}",
         "filSlettet": "{count, plural, =0 {File deleted. No files remaining.} one {File deleted. # file remaining.} other {File deleted. # files remaining.}}",
         "konvertert": "One or more files were changed to another format (PDF) so that it can be submitted.",
         "mappeIkkeTillatt": "Folders cannot be uploaded. Please select individual files instead.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -219,6 +219,8 @@
         "valgteFiler": "Selected files ({antall_filer})",
         "filerTilOpplasting": "Files for upload",
         "antallFiler": "{count, plural, one {# file ready for upload} other {# files ready for upload}}",
+        "antallFilerValgt": "{count, plural, zero {No files remaining} one {# file remaining} other {# files remaining}}",
+        "filSlettet": "{count, plural, =0 {File deleted. No files remaining.} one {File deleted. # file remaining.} other {File deleted. # files remaining.}}",
         "konvertert": "One or more files were changed to another format (PDF) so that it can be submitted.",
         "mappeIkkeTillatt": "Folders cannot be uploaded. Please select individual files instead.",
         "processingWarning": "Upload may take some time. The upload will be cancelled automatically after 3 minutes.",

--- a/messages/nb.json
+++ b/messages/nb.json
@@ -232,7 +232,6 @@
         "valgteFiler": "Valgte filer ({antall_filer})",
         "filerTilOpplasting": "Filer til opplasting",
         "antallFiler": "{count, plural, one {# fil klar til opplasting} other {# filer klare til opplasting}}",
-        "antallFilerValgt": "{count, plural, zero {Ingen filer gjenstår} one {# fil gjenstår} other {# filer gjenstår}}",
         "filSlettet": "{count, plural, =0 {Fil slettet. Ingen filer gjenstår.} one {Fil slettet. # fil gjenstår.} other {Fil slettet. # filer gjenstår.}}",
         "konvertert": "En eller flere filer ble endret til et annet format (PDF) slik at det kan sendes inn.",
         "mappeIkkeTillatt": "Mapper kan ikke lastes opp. Velg enkeltfiler i stedet.",

--- a/messages/nb.json
+++ b/messages/nb.json
@@ -232,6 +232,8 @@
         "valgteFiler": "Valgte filer ({antall_filer})",
         "filerTilOpplasting": "Filer til opplasting",
         "antallFiler": "{count, plural, one {# fil klar til opplasting} other {# filer klare til opplasting}}",
+        "antallFilerValgt": "{count, plural, zero {Ingen filer gjenstår} one {# fil gjenstår} other {# filer gjenstår}}",
+        "filSlettet": "{count, plural, =0 {Fil slettet. Ingen filer gjenstår.} one {Fil slettet. # fil gjenstår.} other {Fil slettet. # filer gjenstår.}}",
         "konvertert": "En eller flere filer ble endret til et annet format (PDF) slik at det kan sendes inn.",
         "mappeIkkeTillatt": "Mapper kan ikke lastes opp. Velg enkeltfiler i stedet.",
         "processingWarning": "Opplasting kan ta litt tid. Opplastingen avbrytes automatisk etter 3 minutter.",

--- a/messages/nn.json
+++ b/messages/nn.json
@@ -219,6 +219,8 @@
         "valgteFiler": "Valde filer ({antall_filer})",
         "filerTilOpplasting": "Filer til opplasting",
         "antallFiler": "{count, plural, one {# fil klar til opplasting} other {# filer klare til opplasting}}",
+        "antallFilerValgt": "{count, plural, zero {Ingen filer att} one {# fil att} other {# filer att}}",
+        "filSlettet": "{count, plural, =0 {Fil sletta. Ingen filer att.} one {Fil sletta. # fil att.} other {Fil sletta. # filer att.}}",
         "konvertert": "Ein eller fleire filer vart endra til eit anna format (PDF) slik at det kan sendast inn.",
         "mappeIkkeTillatt": "Mapper kan ikkje lastast opp. Vel enkeltfiler i staden.",
         "processingWarning": "Opplasting kan ta litt tid. Opplastinga vert avbroten automatisk etter 3 minutt.",

--- a/messages/nn.json
+++ b/messages/nn.json
@@ -219,7 +219,6 @@
         "valgteFiler": "Valde filer ({antall_filer})",
         "filerTilOpplasting": "Filer til opplasting",
         "antallFiler": "{count, plural, one {# fil klar til opplasting} other {# filer klare til opplasting}}",
-        "antallFilerValgt": "{count, plural, zero {Ingen filer att} one {# fil att} other {# filer att}}",
         "filSlettet": "{count, plural, =0 {Fil sletta. Ingen filer att.} one {Fil sletta. # fil att.} other {Fil sletta. # filer att.}}",
         "konvertert": "Ein eller fleire filer vart endra til eit anna format (PDF) slik at det kan sendast inn.",
         "mappeIkkeTillatt": "Mapper kan ikkje lastast opp. Vel enkeltfiler i staden.",

--- a/src/components/filopplasting/FileSelectNew.tsx
+++ b/src/components/filopplasting/FileSelectNew.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import * as R from "remeda";
 import { BodyShort, FileObject, FileUpload, Heading, InlineMessage, VStack } from "@navikt/ds-react";
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { getTusUploader } from "@components/filopplasting/utils/tusUploader";
 import { DocumentState } from "@components/filopplasting/api/useDocumentState";
 
@@ -34,6 +34,16 @@ const FileSelectNew = ({ label, description, tag, docState, id, filesLabel, uplo
     const hasPendingOrProcessing = docState.uploads?.some((u) => u.status === "PENDING" || u.status === "PROCESSING");
 
     const [folderDropError, setFolderDropError] = useState(false);
+    const [deletionMessage, setDeletionMessage] = useState("");
+    const prevCountRef = useRef<number | undefined>(undefined);
+
+    useEffect(() => {
+        const currentCount = docState.uploads?.length ?? 0;
+        if (prevCountRef.current !== undefined && currentCount < prevCountRef.current) {
+            setDeletionMessage(t("filSlettet", { count: currentCount }));
+        }
+        prevCountRef.current = currentCount;
+    }, [docState.uploads?.length, t]);
 
     const showSlowProcessingWarning = useSlowProcessingWarning(hasPendingOrProcessing);
 
@@ -114,6 +124,10 @@ const FileSelectNew = ({ label, description, tag, docState, id, filesLabel, uplo
                         {t("mappeIkkeTillatt")}
                     </InlineMessage>
                 )}
+
+                <div role="status" aria-live="polite" className="sr-only">
+                    {deletionMessage}
+                </div>
 
                 {!!docState.uploads?.length && (
                     <VStack gap="space-8">

--- a/src/components/filopplasting/FileSelectNew.tsx
+++ b/src/components/filopplasting/FileSelectNew.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import * as R from "remeda";
 import { FileObject, FileUpload, Heading, VStack } from "@navikt/ds-react";
 import InlineStatusMessage from "@components/filopplasting/InlineStatusMessage";
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useState } from "react";
 import { getTusUploader } from "@components/filopplasting/utils/tusUploader";
 import { DocumentState } from "@components/filopplasting/api/useDocumentState";
 
@@ -35,16 +35,7 @@ const FileSelectNew = ({ label, description, tag, docState, id, filesLabel, uplo
     const hasPendingOrProcessing = docState.uploads?.some((u) => u.status === "PENDING" || u.status === "PROCESSING");
 
     const [folderDropError, setFolderDropError] = useState(false);
-    const [deletionMessage, setDeletionMessage] = useState("");
-    const prevCountRef = useRef<number | undefined>(undefined);
-
-    useEffect(() => {
-        const currentCount = docState.uploads?.length ?? 0;
-        if (prevCountRef.current !== undefined && currentCount < prevCountRef.current) {
-            setDeletionMessage(t("filSlettet", { count: currentCount }));
-        }
-        prevCountRef.current = currentCount;
-    }, [docState.uploads?.length, t]);
+    const [fileWasDeleted, setFileWasDeleted] = useState(false);
 
     const showSlowProcessingWarning = useSlowProcessingWarning(hasPendingOrProcessing);
 
@@ -53,6 +44,7 @@ const FileSelectNew = ({ label, description, tag, docState, id, filesLabel, uplo
         const [folders, valid] = R.partition(files, (f) => isFolder(f));
 
         setFolderDropError(folders.length > 0);
+        setFileWasDeleted(false);
 
         if (valid.length === 0) return;
         onSelect?.(valid);
@@ -84,6 +76,9 @@ const FileSelectNew = ({ label, description, tag, docState, id, filesLabel, uplo
                 },
             }}
         >
+            <div role="status" aria-live="polite" className="sr-only">
+                {fileWasDeleted && t("filSlettet", { count: docState.uploads?.length ?? 0 })}
+            </div>
             <VStack gap="space-24">
                 <FileSelectUpload
                     label={label ?? t("tittel")}
@@ -100,10 +95,6 @@ const FileSelectNew = ({ label, description, tag, docState, id, filesLabel, uplo
                         {t("mappeIkkeTillatt")}
                     </InlineStatusMessage>
                 )}
-
-                <div role="status" aria-live="polite" className="sr-only">
-                    {deletionMessage}
-                </div>
 
                 {!!docState.uploads?.length && (
                     <VStack gap="space-8">
@@ -148,6 +139,7 @@ const FileSelectNew = ({ label, description, tag, docState, id, filesLabel, uplo
                                         showSlowProcessingWarning &&
                                         (upload.status === "PENDING" || upload.status === "PROCESSING")
                                     }
+                                    onTerminate={() => setFileWasDeleted(true)}
                                 />
                             ))}
                         </VStack>

--- a/src/components/filopplasting/FileUploadItem.tsx
+++ b/src/components/filopplasting/FileUploadItem.tsx
@@ -16,6 +16,7 @@ interface Props {
     status: UploadStatus;
     size?: number;
     showCancelButton?: boolean;
+    onTerminate?: () => void;
 }
 
 const SeOverDescription = () => {
@@ -37,10 +38,12 @@ const FileUploadItem = ({
     status,
     size,
     showCancelButton,
+    onTerminate,
 }: Props) => {
     const t = useTranslations("FileUploadItem");
     const { mutate, isPending } = useMutation({
         mutationFn: () => Upload.terminate(`${browserEnv.NEXT_PUBLIC_UPLOAD_API_BASE}/tus/files/${uploadId}`, {}),
+        onSuccess: () => onTerminate?.(),
         retry: false,
     });
     const isConverted = !!convertedFilename && convertedFilename !== originalFilename;


### PR DESCRIPTION
Grunnen for dette er at sånn som det var, før denne pr, om en søker som bruker skjermlese hadde lastet opp en feil fil
 og deretter slettet den så fikk de ikke noen form for bekreftelse på om filen var slettet eller ikke.
 La også til at tekst blir lest opp basert på hvor mange filer er igjen, om det er mer enn 1.